### PR TITLE
[CAZ-1354] Updated VehicleEntrance attributes and API specification

### DIFF
--- a/src/main/java/uk/gov/caz/psr/dto/VehicleEntranceRequest.java
+++ b/src/main/java/uk/gov/caz/psr/dto/VehicleEntranceRequest.java
@@ -1,7 +1,7 @@
 package uk.gov.caz.psr.dto;
 
 import io.swagger.annotations.ApiModelProperty;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -18,9 +18,9 @@ public class VehicleEntranceRequest {
   @NotNull
   UUID cleanZoneId;
 
-  @ApiModelProperty(value = "${swagger.model.descriptions.vehicle-entrance.date-of-entrance}")
+  @ApiModelProperty(value = "${swagger.model.descriptions.vehicle-entrance.caz-entry-timestamp}")
   @NotNull
-  LocalDate dateOfEntrance;
+  LocalDateTime cazEntryTimestamp;
 
   @ApiModelProperty(value = "${swagger.model.descriptions.vehicle-entrance.vrn}")
   @NotNull
@@ -35,7 +35,7 @@ public class VehicleEntranceRequest {
   public VehicleEntrance toVehicleEntrance() {
     return VehicleEntrance.builder()
         .cleanZoneId(cleanZoneId)
-        .dateOfEntrance(dateOfEntrance)
+        .cazEntryTimestamp(cazEntryTimestamp)
         .vrn(vrn)
         .build();
   }

--- a/src/main/java/uk/gov/caz/psr/model/VehicleEntrance.java
+++ b/src/main/java/uk/gov/caz/psr/model/VehicleEntrance.java
@@ -1,6 +1,6 @@
 package uk.gov.caz.psr.model;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +13,6 @@ import lombok.Data;
 public class VehicleEntrance {
   UUID id;
   private final UUID cleanZoneId;
-  private final LocalDate dateOfEntrance;
+  private final LocalDateTime cazEntryTimestamp;
   private final String vrn;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,7 +64,7 @@ swagger:
         payment-id: GOV.UK Pay unique payment identifier returned by the payment-status GET method
       vehicle-entrance:
         vrn: Vehicle registration number
-        date-of-entrance: ISO 8601 formatted date string that specifies the date on which the vehicle entered the CAZ
+        caz-entry-timestamp: ISO 8601 formatted datetime string that specifies the date and time on which the vehicle entered the CAZ
         clean-zone-id: Clean Air Zone identifier
       payment-initiate:
         vrn: Vehicle registration number

--- a/src/test/java/uk/gov/caz/psr/controller/VehicleEntranceControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/VehicleEntranceControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Nested;
@@ -136,7 +137,7 @@ class VehicleEntranceControllerTest {
     return objectMapper.writeValueAsString(request);
   }
 
-  private LocalDate today() {
-    return LocalDate.now();
+  private LocalDateTime today() {
+    return LocalDateTime.now();
   }
 }

--- a/src/test/java/uk/gov/caz/psr/service/VehicleEntranceServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/VehicleEntranceServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.verify;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,7 +43,7 @@ class VehicleEntranceServiceTest {
     UUID id = UUID.fromString("1ada0539-7528-456e-95eb-f14025792889");
     VehicleEntrance vehicleEntrance = VehicleEntrance.builder()
         .vrn("BW91HUN")
-        .dateOfEntrance(LocalDate.now())
+        .cazEntryTimestamp(LocalDateTime.now())
         .id(id)
         .cleanZoneId(UUID.randomUUID())
         .build();
@@ -62,7 +62,7 @@ class VehicleEntranceServiceTest {
     // given
     VehicleEntrance vehicleEntrance = VehicleEntrance.builder()
         .vrn("BW91HUN")
-        .dateOfEntrance(LocalDate.now())
+        .cazEntryTimestamp(LocalDateTime.now())
         .cleanZoneId(UUID.randomUUID())
         .build();
 


### PR DESCRIPTION
* Updated changeSet which alters `DATE_OF_ENTRANCE` attribute to `CAZ_ENTRY_TIMESTAMP`
* Changed `LocalDate dateOfEntrance` to `LocalDateTime dateTimeOfEntrance`
* Updated swagger documentation
* Updated FE-BE contract (_TODO - no edit rights_)

[CAZ_1354 CARD](https://eaflood.atlassian.net/browse/CAZ-1354)

*Note:*
This change will require database drop and recreation on DEV environment