### PR TITLE
[CAZ-1347] Adds Service to connect Payment with existing VehicleEntrants after successful payment

### DIFF
--- a/src/it/java/uk/gov/caz/psr/SuccessPaymentsJourneyTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/SuccessPaymentsJourneyTestIT.java
@@ -9,7 +9,7 @@ import com.google.common.base.Joiner;
 import com.google.common.io.Resources;
 import io.restassured.RestAssured;
 import java.time.LocalDate;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -40,9 +40,11 @@ import uk.gov.caz.psr.model.PaymentStatus;
 import uk.gov.caz.psr.repository.ExternalPaymentsRepository;
 
 @FullyRunningServerIntegrationTest
-@Sql(scripts = "classpath:data/sql/clear-all-payments.sql",
+@Sql(scripts = {"classpath:data/sql/clear-all-payments.sql",
+    "classpath:data/sql/add-vehicle-entrants.sql"},
     executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@Sql(scripts = "classpath:data/sql/clear-all-payments.sql",
+@Sql(scripts = {"classpath:data/sql/clear-all-payments.sql",
+    "classpath:data/sql/clear-all-vehicle-entrants.sql"},
     executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 public class SuccessPaymentsJourneyTestIT {
 
@@ -60,6 +62,9 @@ public class SuccessPaymentsJourneyTestIT {
   private JdbcTemplate jdbcTemplate;
 
   private ClientAndServer mockServer;
+
+  private final LocalDate dateWithEntityInDB = LocalDate.of(2019, 11, 2);
+  private final LocalDate dateWithoutEntityInDB = LocalDate.of(2019, 11, 10);
 
   @BeforeEach
   public void startMockServer() {
@@ -82,7 +87,7 @@ public class SuccessPaymentsJourneyTestIT {
     andReturnsSuccessStatus();
 
     given()
-        .initiatePaymentRequest(initiatePaymentRequest())
+        .initiatePaymentRequest(initiatePaymentRequest(dateWithEntityInDB))
         .whenSubmitted()
 
         .then()
@@ -96,6 +101,8 @@ public class SuccessPaymentsJourneyTestIT {
 
         .then()
         .paymentEntityStatusIsUpdatedTo(PaymentStatus.SUCCESS)
+        .connectsEntityToPaymentIfEntityWasFound(dateWithEntityInDB)
+        .doesNotConnectEntityToPaymentIfEntityWasNotFound(dateWithoutEntityInDB)
         .withNonNullPaymentAuthorisedTimestamp()
         .andStatusResponseIsReturnedWithMatchinInternalId();
   }
@@ -106,6 +113,7 @@ public class SuccessPaymentsJourneyTestIT {
 
   @RequiredArgsConstructor
   static class PaymentJourneyAssertion {
+
     private final ObjectMapper objectMapper;
     private final JdbcTemplate jdbcTemplate;
 
@@ -190,6 +198,39 @@ public class SuccessPaymentsJourneyTestIT {
       return this;
     }
 
+    public PaymentJourneyAssertion doesNotConnectEntityToPaymentIfEntityWasNotFound(LocalDate date) {
+      verifyThatPaymentWasNotAssignedToEntity(date);
+      return this;
+    }
+
+    public void verifyThatPaymentWasNotAssignedToEntity(LocalDate date) {
+      int vehicleEntrantPaymentsCount = JdbcTestUtils.countRowsInTableWhere(jdbcTemplate,
+          "vehicle_entrant_payment",
+          "caz_id = '" + initiatePaymentRequest.getCleanAirZoneId().toString() + "' AND "
+              + "travel_date = '" + date.toString() + "' AND "
+              + "payment_id = '" + getAndUpdatePaymentResponse.getPaymentId() + "' AND "
+              + "vehicle_entrant_id is not NULL");
+
+      assertThat(vehicleEntrantPaymentsCount).isEqualTo(0);
+    }
+
+
+    public PaymentJourneyAssertion connectsEntityToPaymentIfEntityWasFound(LocalDate date) {
+      verifyThatPaymentWasAssignedToEntity(date);
+      return this;
+    }
+
+    public void verifyThatPaymentWasAssignedToEntity(LocalDate date) {
+      int vehicleEntrantPaymentsCount = JdbcTestUtils.countRowsInTableWhere(jdbcTemplate,
+          "vehicle_entrant_payment",
+          "caz_id = '" + initiatePaymentRequest.getCleanAirZoneId().toString() + "' AND "
+              + "travel_date = '" + date.toString() + "' AND "
+              + "payment_id = '" + getAndUpdatePaymentResponse.getPaymentId() + "' AND "
+              + "vehicle_entrant_id is not NULL");
+
+      assertThat(vehicleEntrantPaymentsCount).isEqualTo(1);
+    }
+
     private void verifyThatPaymentEntityExistsWithStatus(PaymentStatus status) {
       verifyThatPaymentExistsWithMatchingAmountAndCreditCardPaymentMethod();
       verifyThatVehicleEntrantPaymentsExistForMatchingDaysWithStatus(status);
@@ -240,10 +281,10 @@ public class SuccessPaymentsJourneyTestIT {
     }
   }
 
-  private InitiatePaymentRequest initiatePaymentRequest() {
+  private InitiatePaymentRequest initiatePaymentRequest(LocalDate date) {
     return InitiatePaymentRequest.builder()
         .amount(4200)
-        .days(Collections.singletonList(LocalDate.now()))
+        .days(Arrays.asList(dateWithoutEntityInDB, dateWithEntityInDB))
         .cleanAirZoneId(UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4"))
         .returnUrl("http://localhost/return-url")
         .vrn("ND84VSX")

--- a/src/it/resources/data/sql/add-vehicle-entrants.sql
+++ b/src/it/resources/data/sql/add-vehicle-entrants.sql
@@ -1,0 +1,8 @@
+INSERT INTO public.vehicle_entrant(
+  vehicle_entrant_id, caz_entry_timestamp, caz_id, vrn)
+  VALUES
+    ('579c6afe-d076-4dd7-a6a4-376991ad4fbf', '2019-11-01 19:10:25-07', 'b8e53786-c5ca-426a-a701-b14ee74857d4', 'ND84VSX'),
+    ('a6646e5a-c2fb-465b-85f9-ef1464ba3dcc', '2019-11-02 19:10:25-07', 'b8e53786-c5ca-426a-a701-b14ee74857d4', 'ND84VSX'),
+    ('7c12e590-2b6e-4b68-be9f-50591a9f7a13', '2019-11-01 19:10:25-07', 'b3b7b6d4-41d8-469e-a779-b36c78a5fc72', 'ND84VSX'),
+    ('f0381bf6-d1df-4eee-904c-b6e15edbc936', '2019-11-03 19:10:25-07', 'b3b7b6d4-41d8-469e-a779-b36c78a5fc72', 'ND84VSX'),
+    ('3cb51830-87e0-409d-ac43-ed636e34e1db', '2019-11-03 19:10:25-07', 'b8e53786-c5ca-426a-a701-b14ee74857d4', 'ND66VSY');

--- a/src/it/resources/data/sql/clear-all-vehicle-entrants.sql
+++ b/src/it/resources/data/sql/clear-all-vehicle-entrants.sql
@@ -1,0 +1,1 @@
+DELETE FROM vehicle_entrant;

--- a/src/main/java/uk/gov/caz/psr/repository/VehicleEntranceRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/VehicleEntranceRepository.java
@@ -1,5 +1,16 @@
 package uk.gov.caz.psr.repository;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 import uk.gov.caz.psr.model.VehicleEntrance;
 
@@ -7,7 +18,14 @@ import uk.gov.caz.psr.model.VehicleEntrance;
  * A class which handles managing data in {@code VEHICLE_ENTRANCE} table.
  */
 @Repository
+@AllArgsConstructor
 public class VehicleEntranceRepository {
+
+  private static final FindByMapper FIND_BY_MAPPER = new FindByMapper();
+  private final JdbcTemplate jdbcTemplate;
+
+  static final String SELECT_BY_SQL = "SELECT * FROM vehicle_entrant "
+      + "WHERE caz_id = ? AND vrn = ? AND to_char(caz_entry_timestamp, 'YYYY-MM-DD') = ?";
 
   /**
    * Inserts {@code vehicleEntrance} into database unless it exists.
@@ -16,5 +34,55 @@ public class VehicleEntranceRepository {
    */
   public void insertIfNotExists(VehicleEntrance vehicleEntrance) {
     // TODO to be implemented in CAZ-1238
+  }
+
+  /**
+   * Gets {@code vehicleEntrance} from database if it exists.
+   *
+   * @param dateOfEntrance provided dateOfEntrance.
+   * @param cleanZoneId    provided cleanZoneId.
+   * @param vrn            provided vrn.
+   * @return An instance of {@link VehicleEntrance} class wrapped in {@link Optional} if the vehicle
+   *     entrance is found, {@link Optional#empty()} otherwise.
+   * @throws NullPointerException     if {@code dateOfEntrance} is null
+   * @throws NullPointerException     if {@code cleanZoneId} is null
+   * @throws IllegalArgumentException if {@code vrn} is empty.
+   */
+  public Optional<VehicleEntrance> findBy(LocalDate dateOfEntrance, UUID cleanZoneId, String vrn) {
+    Preconditions.checkNotNull(dateOfEntrance, "dayOfEntrance cannot be null");
+    Preconditions.checkNotNull(cleanZoneId, "cleanZoneId cannot be null");
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(vrn), "VRN cannot be null or empty");
+
+    List<VehicleEntrance> results = jdbcTemplate.query(SELECT_BY_SQL,
+        preparedStatement -> {
+          preparedStatement.setObject(1, cleanZoneId);
+          preparedStatement.setString(2, vrn);
+          preparedStatement.setString(3, dateOfEntrance.toString());
+        },
+        FIND_BY_MAPPER
+    );
+    if (results.isEmpty()) {
+      return Optional.empty();
+    }
+    VehicleEntrance vehicleEntrance = results.iterator().next();
+
+    return Optional.of(vehicleEntrance);
+  }
+
+  /**
+   * A class which maps the results obtained from the database to instances of {@link
+   * VehicleEntrance} class.
+   */
+  private static class FindByMapper implements RowMapper<VehicleEntrance> {
+
+    @Override
+    public VehicleEntrance mapRow(ResultSet resultSet, int i) throws SQLException {
+      return VehicleEntrance.builder()
+          .id(UUID.fromString(resultSet.getString("vehicle_entrant_id")))
+          .cleanZoneId(UUID.fromString(resultSet.getString("caz_id")))
+          .vrn(resultSet.getString("vrn"))
+          .cazEntryTimestamp(resultSet.getTimestamp("caz_entry_timestamp").toLocalDateTime())
+          .build();
+    }
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/FinalizePaymentService.java
+++ b/src/main/java/uk/gov/caz/psr/service/FinalizePaymentService.java
@@ -1,0 +1,78 @@
+package uk.gov.caz.psr.service;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.caz.psr.model.Payment;
+import uk.gov.caz.psr.model.PaymentStatus;
+import uk.gov.caz.psr.model.VehicleEntrance;
+import uk.gov.caz.psr.model.VehicleEntrantPayment;
+import uk.gov.caz.psr.repository.VehicleEntranceRepository;
+
+@Service
+@AllArgsConstructor
+public class FinalizePaymentService {
+
+  private final VehicleEntranceRepository vehicleEntranceRepository;
+
+  /**
+   * Adds {@code VehicleEntrantId} to each {@link VehicleEntrantPayment} if {@code Payment} status
+   * is SUCCESS.
+   *
+   * @param payment provided {@link Payment} object
+   * @return {@link Payment} with added VehicleEntrantId if Payment status is SUCCESS
+   * @throws NullPointerException if {@code payment} is null
+   */
+  public Payment connectExistingVehicleEntrants(Payment payment) {
+    Preconditions.checkNotNull(payment, "Payment cannot be null");
+    if (payment.getStatus() != PaymentStatus.SUCCESS) {
+      return payment;
+    }
+
+    return rebuildPayment(payment);
+  }
+
+  /**
+   * Rebuilds {@link Payment} to load {@code VehicleEntranceId} in each {@link
+   * VehicleEntrantPayment} which belongs to provided {@link Payment}.
+   *
+   * @param payment provided {@link Payment} object
+   */
+  private Payment rebuildPayment(Payment payment) {
+    return payment.toBuilder()
+        .vehicleEntrantPayments(rebuildVehicleEntrantPayments(payment.getVehicleEntrantPayments()))
+        .build();
+  }
+
+  /**
+   * Rebuilds List of {@link VehicleEntrantPayment} to load {@code VehicleEntranceId} in each {@link
+   * VehicleEntrantPayment}.
+   *
+   * @param vehicleEntrantPayments provided list of {@link VehicleEntrantPayment}
+   */
+  private List<VehicleEntrantPayment> rebuildVehicleEntrantPayments(
+      List<VehicleEntrantPayment> vehicleEntrantPayments) {
+    return vehicleEntrantPayments.stream()
+        .map(vehicleEntrantPayment -> vehicleEntrantPayment.toBuilder()
+            .vehicleEntrantId(loadVehicleEntrantId(vehicleEntrantPayment))
+            .build())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Loads instance of {@link VehicleEntrance} from the database and returns {@code id} if present.
+   *
+   * @param vehicleEntrantPayment single vehicleEntrantPayment object.
+   */
+  private UUID loadVehicleEntrantId(
+      VehicleEntrantPayment vehicleEntrantPayment) {
+    return vehicleEntranceRepository
+        .findBy(vehicleEntrantPayment.getTravelDate(), vehicleEntrantPayment.getCleanZoneId(),
+            vehicleEntrantPayment.getVrn())
+        .map(VehicleEntrance::getId)
+        .orElse(null);
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/service/GetAndUpdatePaymentsService.java
+++ b/src/main/java/uk/gov/caz/psr/service/GetAndUpdatePaymentsService.java
@@ -21,6 +21,7 @@ public class GetAndUpdatePaymentsService {
 
   private final ExternalPaymentsRepository externalPaymentsRepository;
   private final PaymentRepository internalPaymentsRepository;
+  private final FinalizePaymentService finalizePaymentService;
 
   /**
    * Retrieves the payment by its internal identifier and, provided it exists and has an external
@@ -58,6 +59,7 @@ public class GetAndUpdatePaymentsService {
     } else {
       log.info("Found the external payment, updating its status to '{}' in the database, "
           + "current status '{}'", externalPayment.getStatus(), internalPayment.getStatus());
+      externalPayment = finalizePaymentService.connectExistingVehicleEntrants(externalPayment);
       internalPaymentsRepository.update(externalPayment);
     }
     return Optional.of(externalPayment);

--- a/src/test/java/uk/gov/caz/psr/repository/VehicleEntranceRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/VehicleEntranceRepositoryTest.java
@@ -1,0 +1,80 @@
+package uk.gov.caz.psr.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class VehicleEntranceRepositoryTest {
+
+  @InjectMocks
+  private VehicleEntranceRepository vehicleEntranceRepository;
+
+  @Nested
+  class FindBy {
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenDateOfEntranceIsNull() {
+      // given
+      LocalDate dateOfEntrance = null;
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> vehicleEntranceRepository.findBy(dateOfEntrance, UUID
+              .randomUUID(), "VRN123"));
+
+      // then
+      assertThat(throwable).isInstanceOf(NullPointerException.class)
+          .hasMessage("dayOfEntrance cannot be null");
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenCleanZoneIdIsNull() {
+      // given
+      UUID cleanZoneId = null;
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> vehicleEntranceRepository.findBy(LocalDate.now(), cleanZoneId, "VRN123"));
+
+      // then
+      assertThat(throwable).isInstanceOf(NullPointerException.class)
+          .hasMessage("cleanZoneId cannot be null");
+    }
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionWhenVrnIsEmpty() {
+      // given
+      String vrn = "";
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> vehicleEntranceRepository.findBy(LocalDate.now(), UUID.randomUUID(), vrn));
+
+      // then
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("VRN cannot be null or empty");
+    }
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionWhenVrnIsNull() {
+      // given
+      String vrn = null;
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> vehicleEntranceRepository.findBy(LocalDate.now(), UUID.randomUUID(), vrn));
+
+      // then
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("VRN cannot be null or empty");
+    }
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/service/FinalizePaymentServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/FinalizePaymentServiceTest.java
@@ -1,0 +1,117 @@
+package uk.gov.caz.psr.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.caz.psr.model.Payment;
+import uk.gov.caz.psr.model.PaymentStatus;
+import uk.gov.caz.psr.model.VehicleEntrance;
+import uk.gov.caz.psr.repository.VehicleEntranceRepository;
+import uk.gov.caz.psr.util.TestObjectFactory.Payments;
+
+@ExtendWith(MockitoExtension.class)
+public class FinalizePaymentServiceTest {
+
+  @Mock
+  private VehicleEntranceRepository vehicleEntranceRepository;
+
+  @InjectMocks
+  private FinalizePaymentService finalizePaymentService;
+
+  @Test
+  public void shouldThrowNullPointerExceptionWhenPaymentIsNull() {
+    // given
+    Payment payment = null;
+
+    // when
+    Throwable throwable = catchThrowable(
+        () -> finalizePaymentService.connectExistingVehicleEntrants(payment));
+
+    // then
+    assertThat(throwable).isInstanceOf(NullPointerException.class)
+        .hasMessage("Payment cannot be null");
+  }
+
+  @Test
+  public void shouldReturnProvidedPaymentWhenStatusNotSuccess() {
+    // given
+    Payment payment = Payments.existing();
+
+    // when
+    Payment result = finalizePaymentService.connectExistingVehicleEntrants(payment);
+
+    // then
+    assertThat(result).isEqualTo(payment);
+    verify(vehicleEntranceRepository, never()).findBy(any(), any(), any());
+  }
+
+  @Test
+  public void shouldReturnProvidedPaymentWhenStatusSuccessButNoEntrantsFound() {
+    // given
+    Payment payment = createSuccessPayment();
+    mockNotFoundVehicleEntrance();
+
+    // when
+    Payment result = finalizePaymentService.connectExistingVehicleEntrants(payment);
+
+    // then
+    assertThat(result).isEqualTo(payment);
+    assertThat(result.getVehicleEntrantPayments().get(1).getVehicleEntrantId()).isNull();
+    verify(vehicleEntranceRepository, times(payment.getVehicleEntrantPayments().size()))
+        .findBy(any(), any(), any());
+  }
+
+  @Test
+  public void shouldReturnUpdatedPaymentWhenStatusSuccessAndEntrantsFound() {
+    // given
+    Payment payment = createSuccessPayment();
+    mockFoundVehicleEntrance();
+
+    // when
+    Payment result = finalizePaymentService.connectExistingVehicleEntrants(payment);
+
+    // then
+    assertThat(result).isNotEqualTo(payment);
+    assertThat(result.getVehicleEntrantPayments().get(1).getVehicleEntrantId()).isNotNull();
+    verify(vehicleEntranceRepository, times(payment.getVehicleEntrantPayments().size()))
+        .findBy(any(), any(), any());
+  }
+
+  private Payment createSuccessPayment() {
+    return Payments.existing().toBuilder()
+        .status(PaymentStatus.SUCCESS)
+        .build();
+  }
+
+  private Optional<VehicleEntrance> createVehicleEntrance() {
+    return Optional.ofNullable(VehicleEntrance.builder()
+        .id(UUID.randomUUID())
+        .cazEntryTimestamp(LocalDateTime.now())
+        .vrn("VRN123")
+        .cleanZoneId(UUID.randomUUID())
+        .build());
+  }
+
+  private void mockNotFoundVehicleEntrance() {
+    given(vehicleEntranceRepository.findBy(any(), any(), any())).willReturn(Optional.empty());
+  }
+
+  private void mockFoundVehicleEntrance() {
+    given(vehicleEntranceRepository.findBy(any(), any(), any())).willReturn(
+        createVehicleEntrance()
+    );
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/service/GetAndUpdatePaymentsServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/GetAndUpdatePaymentsServiceTest.java
@@ -32,6 +32,9 @@ class GetAndUpdatePaymentsServiceTest {
   @Mock
   private PaymentRepository internalPaymentsRepository;
 
+  @Mock
+  private FinalizePaymentService finalizePaymentService;
+
   @InjectMocks
   private GetAndUpdatePaymentsService getAndUpdatePaymentsService;
 
@@ -55,7 +58,8 @@ class GetAndUpdatePaymentsServiceTest {
     given(internalPaymentsRepository.findById(paymentId)).willReturn(Optional.empty());
 
     // when
-    Optional<Payment> result = getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+    Optional<Payment> result = getAndUpdatePaymentsService
+        .getExternalPaymentAndUpdateStatus(paymentId);
 
     // then
     assertThat(result).isEmpty();
@@ -71,7 +75,8 @@ class GetAndUpdatePaymentsServiceTest {
     mockInternalPaymentWith(paymentId, externalId);
 
     // when
-    Optional<Payment> result = getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+    Optional<Payment> result = getAndUpdatePaymentsService
+        .getExternalPaymentAndUpdateStatus(paymentId);
 
     // then
     assertThat(result).isEmpty();
@@ -105,9 +110,11 @@ class GetAndUpdatePaymentsServiceTest {
     PaymentStatus externalStatus = PaymentStatus.FAILED;
     Payment payment = mockInternalPaymentWith(paymentId, externalId);
     mockExternalPaymentWithStatus(externalId, payment, externalStatus);
+    mockFinalizePayment(payment);
 
     // when
-    Optional<Payment> result = getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+    Optional<Payment> result = getAndUpdatePaymentsService
+        .getExternalPaymentAndUpdateStatus(paymentId);
 
     // then
     Payment internalPaymentWithExternalStatus = payment.toBuilder().status(externalStatus).build();
@@ -125,7 +132,8 @@ class GetAndUpdatePaymentsServiceTest {
     mockExternalPaymentWithStatus(externalId, payment, externalStatus);
 
     // when
-    Optional<Payment> result = getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+    Optional<Payment> result = getAndUpdatePaymentsService
+        .getExternalPaymentAndUpdateStatus(paymentId);
 
     // then
     Payment internalPaymentWithExternalStatus = payment.toBuilder().status(externalStatus).build();
@@ -152,6 +160,11 @@ class GetAndUpdatePaymentsServiceTest {
     GetPaymentResult externalPayment = toExternalPaymentWithStatus(payment, status);
     given(externalPaymentsRepository.findById(externalId)).willReturn(Optional.of(
         externalPayment));
+  }
+
+  private void mockFinalizePayment(Payment payment) {
+    given(finalizePaymentService.connectExistingVehicleEntrants(any()))
+        .willAnswer(i -> i.getArguments()[0]);
   }
 
   private GetPaymentResult toExternalPaymentWithStatus(Payment payment, PaymentStatus status) {


### PR DESCRIPTION
Jira Card: https://eaflood.atlassian.net/browse/CAZ-1347

Added new service to inject to successfully finished VehicleEntrantPayments objects vehicleEntratntId if already exists. 
Used in update Payment process.
Added Unit tests
Updated Integration test with a successful path of payment.  