### PR TITLE
[CAZ-1414][CAZ-1418] ChargeSettlementController - integration with service and repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,6 @@ docker-rm:
 	docker rm `docker ps -a -q`
 
 docker-clean: docker-stop docker-rm
+
+sonar:
+	./mvnw sonar:sonar

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: caz-payments
+
+  sonarqube:
+    image: sonarqube
+    container_name: sonarqube.docker
+    ports:
+      - 9000:9000

--- a/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
@@ -1,0 +1,137 @@
+package uk.gov.caz.psr;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.caz.correlationid.Constants;
+import uk.gov.caz.psr.annotation.IntegrationTest;
+import uk.gov.caz.psr.controller.ChargeSettlementController;
+import uk.gov.caz.psr.controller.Headers;
+import uk.gov.caz.psr.dto.PaymentStatusResponse;
+import uk.gov.caz.psr.model.InternalPaymentStatus;
+import uk.gov.caz.psr.model.PaymentStatus;
+import uk.gov.caz.psr.repository.PaymentStatusRepository;
+import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusFactory;
+
+@Sql(scripts = "classpath:data/sql/add-payments-for-payment-status.sql",
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:data/sql/clear-all-payments.sql",
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@IntegrationTest
+@AutoConfigureMockMvc
+public class GetChargeSettlementPaymentStatusTestIT {
+
+  private static final String VALID_VRN = "ND84VSX";
+  private static final String VALID_DATE_STRING = "2019-11-01";
+
+  private static final String VALID_DATE_WITH_STATUSES_WHICH_IS_DIFFERENT_THAN_PAID = "2019-11-02";
+  private static final String VALID_DATE_WITH_DIFFERENT_STATUSES = "2019-11-03";
+  private static final String VALID_DUPLICATED_DATE_STRING = "2019-11-04";
+  private static final String VALID_CAZ_ID = "b8e53786-c5ca-426a-a701-b14ee74857d4";
+  private static final String VALID_CORRELATION_HEADER = "79b7a48f-27c7-4947-bd1c-670f981843ef";
+
+  private static final String VALID_EXTERNAL_ID = "54321test";
+  private static final String VALID_CASE_REFERENCE = "case-reference123";
+  private static final String PAYMENT_STATUS_GET_PATH = ChargeSettlementController.BASE_PATH +
+      ChargeSettlementController.PAYMENT_STATUS_PATH;
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private PaymentStatusRepository paymentStatusRepository;
+
+  @Test
+  public void shouldReturn200WithNotPaidStatusWhenDoesNotExistInDatabase() throws Exception {
+    String nonExistingVrn = "CAS222";
+
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", nonExistingVrn)
+        .param("dateOfCazEntry", VALID_DATE_STRING))
+        .andExpect(status().isOk())
+        .andExpect(content().json(getNotPaidResponse()));
+
+  }
+
+  @Test
+  public void shouldReturn500WhenThereAreTwoPaidPaymentStatusesWithSameVrnAndDateOfEntrance()
+      throws Exception {
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", VALID_VRN)
+        .param("dateOfCazEntry", VALID_DUPLICATED_DATE_STRING))
+        .andExpect(status().is5xxServerError());
+  }
+
+  @Test
+  public void shouldReturn200AndPaidPaymentStatusWhenThereAreManyRecordsAndOneOfThemIsPaid()
+      throws Exception {
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", VALID_VRN)
+        .param("dateOfCazEntry", VALID_DATE_WITH_DIFFERENT_STATUSES))
+        .andExpect(status().isOk())
+        .andExpect(content().json(
+            getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE, VALID_EXTERNAL_ID)));
+  }
+
+  @Test
+  public void shouldReturn200AndTheExistingPaymentWhenThereAreNoPaid() throws Exception {
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", VALID_VRN)
+        .param("dateOfCazEntry", VALID_DATE_WITH_STATUSES_WHICH_IS_DIFFERENT_THAN_PAID))
+        .andExpect(status().isOk())
+        .andExpect(content().json(
+            getResponseWith(InternalPaymentStatus.REFUNDED, VALID_CASE_REFERENCE,
+                VALID_EXTERNAL_ID)));
+  }
+
+  private String getNotPaidResponse() {
+    PaymentStatusResponse paymentStatusResponse = PaymentStatusResponse
+        .from(PaymentStatus.getEmptyPaymentStatusResponse());
+
+    return toJsonString(paymentStatusResponse);
+  }
+
+  private String getResponseWith(InternalPaymentStatus internalPaymentStatus, String caseReference,
+      String externalId) {
+    PaymentStatusResponse paymentStatusResponse = PaymentStatusResponse
+        .from(PaymentStatusFactory.with(
+            internalPaymentStatus,
+            caseReference,
+            externalId
+        ));
+
+    return toJsonString(paymentStatusResponse);
+  }
+
+  @SneakyThrows
+  private String toJsonString(Object response) {
+    return objectMapper.writeValueAsString(response);
+  }
+}

--- a/src/it/java/uk/gov/caz/psr/repository/PaymentStatusRepositoryTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/repository/PaymentStatusRepositoryTestIT.java
@@ -25,16 +25,16 @@ class PaymentStatusRepositoryTestIT {
   @Test
   public void shouldReturnNonEmptyCollection() {
     // given
-      LocalDate dateOfCazEntry = LocalDate.of(2019, 11, 04);
-      String vrn = "ND84VSX";
-      UUID cazId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
+    LocalDate dateOfCazEntry = LocalDate.of(2019, 11, 04);
+    String vrn = "ND84VSX";
+    UUID cazId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
 
     // when
-      Collection<PaymentStatus> results = repository
-          .findByCazIdAndVrnAndEntryDate(cazId, vrn, dateOfCazEntry);
+    Collection<PaymentStatus> results = repository
+        .findByCazIdAndVrnAndEntryDate(cazId, vrn, dateOfCazEntry);
 
     // then
-     assertThat(results).isNotEmpty();
+    assertThat(results).isNotEmpty();
   }
 }
 

--- a/src/it/resources/data/sql/add-payments-for-payment-status.sql
+++ b/src/it/resources/data/sql/add-payments-for-payment-status.sql
@@ -1,0 +1,23 @@
+INSERT INTO payment(
+	payment_id, payment_method, payment_provider_id, total_paid, payment_submitted_timestamp, payment_authorised_timestamp)
+	VALUES
+	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', '12345test', 100, now(), now()),
+	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', '54321test', 200, now(), now());
+
+INSERT INTO vehicle_entrant_payment(
+	vehicle_entrant_payment_id, vehicle_entrant_id, payment_id, vrn, caz_id, travel_date, charge_paid, payment_status, case_reference)
+	VALUES
+	  ('43ea77cc-93cb-4df3-b731-5244c0de9cc8', null, 'b71b72a5-902f-4a16-a91d-1a4463b801db', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-01', 50, 'PAID', 'case-reference123'),
+
+    -- Valid with REFUNDED status
+	  ('688f8278-2f0f-4710-bb7c-6b0cca04c1bc', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 50, 'REFUNDED', 'case-reference123'),
+
+	  -- Same day and VRN, different statuses:
+	  ('1504a9dc-44f0-484d-9687-35ecd15105ca', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 100, 'NOT_PAID', 'case-reference123'),
+	  ('e560c78a-d2e1-4a16-a8f6-39a8a83c055f', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 100, 'REFUNDED', 'case-reference123'),
+	  ('9cc2dd1a-905e-4eaf-af85-0b14f95aab89', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 100, 'PAID', 'case-reference123'),
+
+    -- Duplicated PAID record for same day and VRN:
+	  ('21b7049d-b978-482f-a882-4de6bb9d699c', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-04', 100, 'PAID', 'case-reference123'),
+	  ('05808800-f74d-4443-b83f-e379192096f1', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-04', 100, 'PAID', 'case-reference123');
+

--- a/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
@@ -2,16 +2,16 @@ package uk.gov.caz.psr.controller;
 
 import java.util.UUID;
 import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.caz.psr.dto.ChargeSettlementPaymentStatus;
 import uk.gov.caz.psr.dto.PaymentInfoRequest;
 import uk.gov.caz.psr.dto.PaymentInfoResponse;
 import uk.gov.caz.psr.dto.PaymentStatusRequest;
 import uk.gov.caz.psr.dto.PaymentStatusResponse;
 import uk.gov.caz.psr.dto.PaymentStatusUpdateRequest;
 import uk.gov.caz.psr.dto.PaymentUpdateSuccessResponse;
+import uk.gov.caz.psr.model.PaymentStatus;
+import uk.gov.caz.psr.service.ChargeSettlementService;
 import uk.gov.caz.psr.service.PaymentStatusUpdateService;
 
 /**
@@ -19,14 +19,14 @@ import uk.gov.caz.psr.service.PaymentStatusUpdateService;
  */
 @RestController
 @AllArgsConstructor
-@Slf4j
 public class ChargeSettlementController implements ChargeSettlementControllerApiSpec {
 
   public static final String BASE_PATH = "/v1/charge-settlement";
   public static final String PAYMENT_INFO_PATH = "/payment-info";
   public static final String PAYMENT_STATUS_PATH = "/payment-status";
 
-  private PaymentStatusUpdateService paymentStatusUpdateService;
+  private final PaymentStatusUpdateService paymentStatusUpdateService;
+  private final ChargeSettlementService chargeSettlementService;
 
   @Override
   public ResponseEntity<PaymentInfoResponse> getPaymentInfo(PaymentInfoRequest paymentInfoRequest) {
@@ -34,16 +34,17 @@ public class ChargeSettlementController implements ChargeSettlementControllerApi
   }
 
   @Override
-  public ResponseEntity<PaymentStatusResponse> getPaymentStatus(PaymentStatusRequest request) {
-    log.info("Received request: {}", request);
+  public ResponseEntity<PaymentStatusResponse> getPaymentStatus(PaymentStatusRequest request,
+      String apiKey) {
+    UUID cleanAirZoneId = UUID.fromString(apiKey);
 
-    PaymentStatusResponse fakeResponse = PaymentStatusResponse.builder()
-        .paymentStatus(ChargeSettlementPaymentStatus.PAID)
-        .paymentId("350be6da-10f1-41fe-9840-98c738ec763e")
-        .caseReference("sample-case-reference")
-        .build();
+    PaymentStatus paymentStatus = chargeSettlementService
+        .findChargeSettlement(
+            cleanAirZoneId,
+            request.getVrn(),
+            request.getDateOfCazEntry());
 
-    return ResponseEntity.ok(fakeResponse);
+    return ResponseEntity.ok(PaymentStatusResponse.from(paymentStatus));
   }
 
   @Override

--- a/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementControllerApiSpec.java
@@ -104,7 +104,10 @@ public interface ChargeSettlementControllerApiSpec {
           paramType = "header")
   })
   @GetMapping(ChargeSettlementController.PAYMENT_STATUS_PATH)
-  ResponseEntity<PaymentStatusResponse> getPaymentStatus(@Valid PaymentStatusRequest request);
+  ResponseEntity<PaymentStatusResponse> getPaymentStatus(
+      @Valid PaymentStatusRequest request,
+      @RequestHeader(Headers.X_API_KEY) String apiKey
+  );
 
   /**
    * Allows Local Authorities to update the status of one or more paid CAZ charges to reflect any

--- a/src/main/java/uk/gov/caz/psr/dto/ChargeSettlementPaymentStatus.java
+++ b/src/main/java/uk/gov/caz/psr/dto/ChargeSettlementPaymentStatus.java
@@ -2,6 +2,9 @@ package uk.gov.caz.psr.dto;
 
 import uk.gov.caz.psr.model.InternalPaymentStatus;
 
+/**
+ * Class represents charge settlement statuses.
+ */
 public enum ChargeSettlementPaymentStatus {
   PAID,
   NOT_PAID,

--- a/src/main/java/uk/gov/caz/psr/dto/PaymentStatusRequest.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentStatusRequest.java
@@ -21,4 +21,3 @@ public class PaymentStatusRequest {
   @DateTimeFormat(iso = ISO.DATE)
   LocalDate dateOfCazEntry;
 }
-

--- a/src/main/java/uk/gov/caz/psr/model/PaymentStatus.java
+++ b/src/main/java/uk/gov/caz/psr/model/PaymentStatus.java
@@ -26,4 +26,19 @@ public class PaymentStatus {
    * and Local Authority.
    */
   String caseReference;
+
+
+  private static final PaymentStatus EMPTY = PaymentStatus.builder()
+      .status(InternalPaymentStatus.NOT_PAID)
+      .build();
+
+  /**
+   * Helper method which returns built object with NOT_PAID status.
+   *
+   * @return {@link PaymentStatus}
+   */
+  public static PaymentStatus getEmptyPaymentStatusResponse() {
+    return EMPTY;
+  }
+
 }

--- a/src/main/java/uk/gov/caz/psr/service/ChargeSettlementService.java
+++ b/src/main/java/uk/gov/caz/psr/service/ChargeSettlementService.java
@@ -1,0 +1,77 @@
+package uk.gov.caz.psr.service;
+
+import com.google.common.collect.Iterables;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.caz.psr.model.InternalPaymentStatus;
+import uk.gov.caz.psr.model.PaymentStatus;
+import uk.gov.caz.psr.repository.PaymentStatusRepository;
+
+/**
+ * Class responsible to call internal repository for payment info.
+ */
+@Service
+@AllArgsConstructor
+public class ChargeSettlementService {
+
+  private final PaymentStatusRepository paymentStatusRepository;
+
+  /**
+   * Method that call internal repository and detects if the payment was done against the CAZ entry
+   * represented by the passed attributes.
+   *
+   * @param cazId          provided clean air zone ID
+   * @param vrn            of the car that needs payment info
+   * @param dateOfCazEntry for which payment info is searched
+   * @return {@link PaymentStatus}
+   * @throws IllegalStateException when single day was paid twice
+   */
+  public PaymentStatus findChargeSettlement(UUID cazId, String vrn,
+      LocalDate dateOfCazEntry) {
+
+    Collection<PaymentStatus> paymentStatuses = paymentStatusRepository
+        .findByCazIdAndVrnAndEntryDate(cazId, vrn, dateOfCazEntry);
+    Collection<PaymentStatus> paidPaymentStatuses = getPaidPaymentStatuses(paymentStatuses);
+
+    return getPaymentStatusToReturn(paymentStatuses, paidPaymentStatuses);
+  }
+
+  /**
+   * Method receives a collection of PaymentStatuses and returns only those with status PAID.
+   *
+   * @param paymentStatuses all PaymentStatuses to filter
+   * @return collection of {@link PaymentStatus} with PAID statuses
+   */
+  private Collection<PaymentStatus> getPaidPaymentStatuses(
+      Collection<PaymentStatus> paymentStatuses) {
+
+    return paymentStatuses
+        .stream()
+        .filter(p -> p.getStatus() == InternalPaymentStatus.PAID)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Method decides which PaymentStatus object should be returned.
+   *
+   * @param allPaymentStatuses  all PaymentStatuses returned by repository
+   * @param paidPaymentStatuses filtered PaymentStatuses with PAID status
+   * @return {@link PaymentStatus}
+   */
+  private PaymentStatus getPaymentStatusToReturn(Collection<PaymentStatus> allPaymentStatuses,
+      Collection<PaymentStatus> paidPaymentStatuses) {
+    if (paidPaymentStatuses.size() > 1) {
+      throw new IllegalStateException("More than one paid VehicleEntrantPayment found");
+    }
+
+    if (paidPaymentStatuses.size() == 1) {
+      return paidPaymentStatuses.iterator().next();
+    }
+
+    return Iterables.getFirst(allPaymentStatuses, PaymentStatus.getEmptyPaymentStatusResponse());
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/service/ChargeSettlementServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/ChargeSettlementServiceTest.java
@@ -1,0 +1,113 @@
+package uk.gov.caz.psr.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.caz.psr.model.InternalPaymentStatus;
+import uk.gov.caz.psr.model.PaymentStatus;
+import uk.gov.caz.psr.repository.PaymentStatusRepository;
+import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusFactory;
+
+@ExtendWith(MockitoExtension.class)
+class ChargeSettlementServiceTest {
+
+  public static final String ANY_VRN = "CAS123";
+  public static final UUID ANY_CAZ_ID = UUID.randomUUID();
+  public static final LocalDate ANY_DATE = LocalDate.now();
+
+  @Mock
+  private PaymentStatusRepository paymentStatusRepository;
+
+  @InjectMocks
+  private ChargeSettlementService chargeSettlementService;
+
+  @Test
+  void shouldReturnNotPaidWhenRepositoryReturnsEmptyCollection() {
+    //given
+    mockEmptyCollection();
+
+    //when
+    PaymentStatus paymentStatus = chargeSettlementService
+        .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
+
+    //then
+    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.NOT_PAID);
+  }
+
+  @Test
+  void shouldThrowIllegalStateExceptionWhenRepositoryReturnsMoreThanOnePaidPaymentStatus() {
+    // given
+    mockMultiplePaidPaymentStatuses();
+
+    //when
+    Throwable throwable = catchThrowable(() ->
+        chargeSettlementService.findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE)
+    );
+
+    //then
+    assertThat(throwable).isInstanceOf(IllegalStateException.class)
+        .hasMessage("More than one paid VehicleEntrantPayment found");
+  }
+
+  @Test
+  void shouldReturnPaidPaymentStatusWhenHasOnePaidAndOtherPaymentStatusesWithDifferentStatuses() {
+    // given
+    mockMultiplePaymentStatusesButOnlyOnePaid();
+
+    // when
+    PaymentStatus paymentStatus = chargeSettlementService
+        .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
+
+    // then
+    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.PAID);
+  }
+
+  @Test
+  void shouldReturnTheExistingPaymentStatusWhenThereIsNoPaidOne() {
+    //given
+    mockSingleNotPaidPaymentStatus();
+
+    //when
+    PaymentStatus paymentStatus = chargeSettlementService
+        .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
+
+    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.REFUNDED);
+  }
+
+  private void mockEmptyCollection() {
+    when(paymentStatusRepository.findByCazIdAndVrnAndEntryDate(ANY_CAZ_ID, ANY_VRN, ANY_DATE))
+        .thenReturn(Collections.emptyList());
+  }
+
+  private void mockMultiplePaidPaymentStatuses() {
+    when(paymentStatusRepository.findByCazIdAndVrnAndEntryDate(ANY_CAZ_ID, ANY_VRN, ANY_DATE))
+        .thenReturn(Arrays.asList(
+            PaymentStatusFactory.anyWithStatus(InternalPaymentStatus.PAID),
+            PaymentStatusFactory.anyWithStatus(InternalPaymentStatus.PAID)));
+  }
+
+  private void mockMultiplePaymentStatusesButOnlyOnePaid() {
+    when(paymentStatusRepository.findByCazIdAndVrnAndEntryDate(ANY_CAZ_ID, ANY_VRN, ANY_DATE))
+        .thenReturn((Arrays.asList(
+            PaymentStatusFactory.anyWithStatus(InternalPaymentStatus.NOT_PAID),
+            PaymentStatusFactory.anyWithStatus(InternalPaymentStatus.REFUNDED),
+            PaymentStatusFactory.anyWithStatus(InternalPaymentStatus.CHARGEBACK),
+            PaymentStatusFactory.anyWithStatus(InternalPaymentStatus.PAID))));
+  }
+
+  private void mockSingleNotPaidPaymentStatus() {
+    when(paymentStatusRepository.findByCazIdAndVrnAndEntryDate(ANY_CAZ_ID, ANY_VRN, ANY_DATE))
+        .thenReturn(
+            Arrays.asList(PaymentStatusFactory.anyWithStatus(InternalPaymentStatus.REFUNDED)));
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
+++ b/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
@@ -16,6 +16,7 @@ import uk.gov.caz.psr.model.ExternalPaymentStatus;
 import uk.gov.caz.psr.model.InternalPaymentStatus;
 import uk.gov.caz.psr.model.Payment;
 import uk.gov.caz.psr.model.PaymentMethod;
+import uk.gov.caz.psr.model.PaymentStatus;
 import uk.gov.caz.psr.model.VehicleEntrant;
 import uk.gov.caz.psr.model.VehicleEntrantPayment;
 import uk.gov.caz.psr.model.VehicleEntrantPaymentStatusUpdate;
@@ -296,6 +297,7 @@ public class TestObjectFactory {
   }
 
   public static class VehicleEntrantPaymentStatusUpdates {
+
     public static VehicleEntrantPaymentStatusUpdate any() {
       return VehicleEntrantPaymentStatusUpdate.builder()
           .caseReference("Test case Reference")
@@ -304,6 +306,26 @@ public class TestObjectFactory {
           .vrn("VRN123")
           .dateOfCazEntry(LocalDate.now())
           .cleanAirZoneId(UUID.randomUUID())
+          .build();
+    }
+  }
+
+  public static class PaymentStatusFactory {
+
+    public static PaymentStatus anyWithStatus(InternalPaymentStatus internalPaymentStatus) {
+      return PaymentStatus.builder()
+          .caseReference("any-valid-case-reference")
+          .status(internalPaymentStatus)
+          .externalId(UUID.randomUUID().toString())
+          .build();
+    }
+
+    public static PaymentStatus with(InternalPaymentStatus internalPaymentStatus,
+        String caseReference, String externalId) {
+      return PaymentStatus.builder()
+          .caseReference(caseReference)
+          .status(internalPaymentStatus)
+          .externalId(externalId)
           .build();
     }
   }


### PR DESCRIPTION
**Introduced changes**
* Implemented `ChargeSettlementService` which calls `paymentStatusRepository` and finds proper `PaymentStatus`
* Implemented endpoint in `ChargeSettlementController`
* Implemented unit and integration tests.
---
**Additional info**

* [Link to JIRA Card - CAZ-1414](https://eaflood.atlassian.net/browse/CAZ-1414) - service to handle happy path
* [Link to JIRA Card - CAZ-1418](https://eaflood.atlassian.net/browse/CAZ-1418) - glue endpoint with service and repository to provide complete functionality