### PR TITLE
[CAZ-1348] Handle happy path of ChargeSettlement PaymentStatus update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,6 @@
                 <!-- TODO remove once ChargeSettlementController is implemented and tested -->
                 <exclude>**/psr/controller/ChargeSettlementController.class</exclude>
                 <exclude>**/psr/dto/ChargeSettlementPaymentStatus.class</exclude>
-                <exclude>**/psr/repository/VehicleEntrantPaymentRepository.class</exclude>
               </excludes>
               <rules>
                 <rule>

--- a/src/it/java/uk/gov/caz/psr/SuccessPaymentStatusUpdateTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/SuccessPaymentStatusUpdateTestIT.java
@@ -1,0 +1,160 @@
+package uk.gov.caz.psr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.caz.security.SecurityHeadersInjector.CACHE_CONTROL_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.CACHE_CONTROL_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.CONTENT_SECURITY_POLICY_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.CONTENT_SECURITY_POLICY_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.PRAGMA_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.PRAGMA_HEADER_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.STRICT_TRANSPORT_SECURITY_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.STRICT_TRANSPORT_SECURITY_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_CONTENT_TYPE_OPTIONS_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_CONTENT_TYPE_OPTIONS_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_FRAME_OPTIONS_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_FRAME_OPTIONS_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.jdbc.JdbcTestUtils;
+import uk.gov.caz.correlationid.Constants;
+import uk.gov.caz.psr.annotation.FullyRunningServerIntegrationTest;
+import uk.gov.caz.psr.controller.ChargeSettlementController;
+import uk.gov.caz.psr.controller.Headers;
+import uk.gov.caz.psr.dto.PaymentStatusUpdateDetails;
+import uk.gov.caz.psr.dto.PaymentStatusUpdateRequest;
+import uk.gov.caz.psr.model.InternalPaymentStatus;
+import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusUpdateDetailsFactory;
+
+@FullyRunningServerIntegrationTest
+@Sql(scripts = "classpath:data/sql/add-payments.sql",
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:data/sql/clear-all-payments.sql",
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Slf4j
+public class SuccessPaymentStatusUpdateTestIT {
+
+  @LocalServerPort
+  int randomServerPort;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+  @BeforeEach
+  public void startMockServer() {
+    RestAssured.port = randomServerPort;
+    RestAssured.baseURI = "http://localhost";
+    RestAssured.basePath = ChargeSettlementController.BASE_PATH +
+        ChargeSettlementController.PAYMENT_STATUS_PATH;
+  }
+
+  @Test
+  public void successPaymentStatusUpdateJourney() {
+    given()
+        .paymentStatusUpdateRequest(paymentStatusUpdateRequest())
+        .whenSubmitted()
+        .then()
+        .vehicleEntrantPaymentsAreUpdatedInTheDatabse();
+  }
+
+  private PaymentStatusUpdateJourneyAssertion given() {
+    return new PaymentStatusUpdateJourneyAssertion(objectMapper, jdbcTemplate);
+  }
+
+  private PaymentStatusUpdateRequest paymentStatusUpdateRequest() {
+    return PaymentStatusUpdateRequest.builder()
+        .vrn("ND84VSX")
+        .statusUpdates(validStatusUpdates())
+        .build();
+  }
+
+  private List<PaymentStatusUpdateDetails> validStatusUpdates() {
+    return Arrays.asList(
+        PaymentStatusUpdateDetailsFactory.refundedWithDateOfCazEntry(LocalDate.of(2019, 11, 1)),
+        PaymentStatusUpdateDetailsFactory
+            .refundedWithDateOfCazEntryAndPaymentId(LocalDate.of(2019, 11, 3), "12345test")
+    );
+  }
+
+  @RequiredArgsConstructor
+  static class PaymentStatusUpdateJourneyAssertion {
+
+    private final ObjectMapper objectMapper;
+    private final JdbcTemplate jdbcTemplate;
+    private final UUID cleanAirZoneId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
+
+    private PaymentStatusUpdateRequest paymentStatusUpdateRequest;
+
+
+    public PaymentStatusUpdateJourneyAssertion paymentStatusUpdateRequest(
+        PaymentStatusUpdateRequest request) {
+      this.paymentStatusUpdateRequest = request;
+      return this;
+    }
+
+    public PaymentStatusUpdateJourneyAssertion then() {
+      return this;
+    }
+
+    public PaymentStatusUpdateJourneyAssertion whenSubmitted() {
+      String correlationId = "79b7a48f-27c7-4947-bd1c-670f981843ef";
+
+      RestAssured
+          .given()
+          .accept(MediaType.APPLICATION_JSON.toString())
+          .contentType(MediaType.APPLICATION_JSON.toString())
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(Headers.X_API_KEY, cleanAirZoneId)
+          .body(toJsonString(paymentStatusUpdateRequest))
+          .when()
+          .put()
+          .then()
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(STRICT_TRANSPORT_SECURITY_HEADER, STRICT_TRANSPORT_SECURITY_VALUE)
+          .header(PRAGMA_HEADER, PRAGMA_HEADER_VALUE)
+          .header(X_CONTENT_TYPE_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_VALUE)
+          .header(X_FRAME_OPTIONS_HEADER, X_FRAME_OPTIONS_VALUE)
+          .header(CONTENT_SECURITY_POLICY_HEADER, CONTENT_SECURITY_POLICY_VALUE)
+          .header(CACHE_CONTROL_HEADER, CACHE_CONTROL_VALUE)
+          .statusCode(HttpStatus.OK.value());
+      return this;
+    }
+
+    @SneakyThrows
+    private String toJsonString(Object request) {
+      return objectMapper.writeValueAsString(request);
+    }
+
+    public PaymentStatusUpdateJourneyAssertion vehicleEntrantPaymentsAreUpdatedInTheDatabse() {
+      verifyThatRefundedVehicleEntrantPaymentsExists();
+      return this;
+    }
+
+    private void verifyThatRefundedVehicleEntrantPaymentsExists() {
+      int vehicleEntrantCount = JdbcTestUtils.countRowsInTableWhere(jdbcTemplate,
+          "vehicle_entrant_payment",
+          "caz_id = '" + cleanAirZoneId.toString() + "' AND "
+              + "vrn = '" + paymentStatusUpdateRequest.getVrn() + "' AND "
+              + "payment_status = '" + InternalPaymentStatus.REFUNDED.name() + "'");
+      assertThat(vehicleEntrantCount).isEqualTo(2);
+    }
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
@@ -1,5 +1,7 @@
 package uk.gov.caz.psr.controller;
 
+import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,17 +11,21 @@ import uk.gov.caz.psr.dto.PaymentStatusRequest;
 import uk.gov.caz.psr.dto.PaymentStatusResponse;
 import uk.gov.caz.psr.dto.PaymentStatusUpdateRequest;
 import uk.gov.caz.psr.dto.PaymentUpdateSuccessResponse;
+import uk.gov.caz.psr.service.PaymentStatusUpdateService;
 
 /**
  * A controller which exposes endpoints dealing with charge settlement.
  */
 @RestController
+@AllArgsConstructor
 @Slf4j
 public class ChargeSettlementController implements ChargeSettlementControllerApiSpec {
 
-  static final String BASE_PATH = "/v1/charge-settlement";
-  static final String PAYMENT_INFO_PATH = "/payment-info";
-  static final String PAYMENT_STATUS_PATH = "/payment-status";
+  public static final String BASE_PATH = "/v1/charge-settlement";
+  public static final String PAYMENT_INFO_PATH = "/payment-info";
+  public static final String PAYMENT_STATUS_PATH = "/payment-status";
+
+  private PaymentStatusUpdateService paymentStatusUpdateService;
 
   @Override
   public ResponseEntity<PaymentInfoResponse> getPaymentInfo() {
@@ -46,7 +52,11 @@ public class ChargeSettlementController implements ChargeSettlementControllerApi
   }
 
   @Override
-  public PaymentUpdateSuccessResponse updatePaymentStatus(PaymentStatusUpdateRequest request) {
+  public PaymentUpdateSuccessResponse updatePaymentStatus(PaymentStatusUpdateRequest request,
+      String apiKey) {
+    UUID cleanAirZoneId = UUID.fromString(apiKey);
+    paymentStatusUpdateService
+        .processUpdate(request.toVehicleEntrantPaymentStatusUpdates(cleanAirZoneId));
     return new PaymentUpdateSuccessResponse();
   }
 }

--- a/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementControllerApiSpec.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.caz.correlationid.Constants;
 import uk.gov.caz.psr.dto.PaymentInfoResponse;
@@ -53,7 +54,7 @@ public interface ChargeSettlementControllerApiSpec {
           required = true,
           value = "UUID formatted string to track the request through the enquiries stack",
           paramType = "header"),
-      @ApiImplicitParam(name = "x-api-key",
+      @ApiImplicitParam(name = Headers.X_API_KEY,
           required = true, value = "API key used to access the service",
           paramType = "header"),
       @ApiImplicitParam(name = "Authorization",
@@ -93,7 +94,7 @@ public interface ChargeSettlementControllerApiSpec {
           required = true,
           value = "UUID formatted string to track the request through the enquiries stack",
           paramType = "header"),
-      @ApiImplicitParam(name = "x-api-key",
+      @ApiImplicitParam(name = Headers.X_API_KEY,
           required = true, value = "API key used to access the service",
           paramType = "header"),
       @ApiImplicitParam(name = "Authorization",
@@ -133,7 +134,7 @@ public interface ChargeSettlementControllerApiSpec {
           required = true,
           value = "UUID formatted string to track the request through the enquiries stack",
           paramType = "header"),
-      @ApiImplicitParam(name = "x-api-key",
+      @ApiImplicitParam(name = Headers.X_API_KEY,
           required = true, value = "API key used to access the service",
           paramType = "header"),
       @ApiImplicitParam(name = "Authorization",
@@ -143,5 +144,6 @@ public interface ChargeSettlementControllerApiSpec {
   })
   @PutMapping(ChargeSettlementController.PAYMENT_STATUS_PATH)
   PaymentUpdateSuccessResponse updatePaymentStatus(
-      @Valid @RequestBody PaymentStatusUpdateRequest request);
+      @Valid @RequestBody PaymentStatusUpdateRequest request,
+      @RequestHeader(Headers.X_API_KEY) String apiKey);
 }

--- a/src/main/java/uk/gov/caz/psr/controller/Headers.java
+++ b/src/main/java/uk/gov/caz/psr/controller/Headers.java
@@ -1,0 +1,12 @@
+package uk.gov.caz.psr.controller;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utility class which is used to store possible header keys.
+ *
+ */
+@UtilityClass
+public class Headers {
+  public static final String X_API_KEY = "x-api-key";
+}

--- a/src/main/java/uk/gov/caz/psr/model/VehicleEntrantPaymentStatusUpdate.java
+++ b/src/main/java/uk/gov/caz/psr/model/VehicleEntrantPaymentStatusUpdate.java
@@ -1,0 +1,43 @@
+package uk.gov.caz.psr.model;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * An entity which represents a details to update payment status of {@code VehicleEntrantPayment}.
+ */
+@Value
+@Builder
+public class VehicleEntrantPaymentStatusUpdate {
+  /**
+   * The internal unique identifier of Clean Air Zone.
+   */
+  UUID cleanAirZoneId;
+
+  /**
+   * Vehicle registration number.
+   */
+  String vrn;
+
+  /**
+   * Date of entry to Clean Air Zone.
+   */
+  LocalDate dateOfCazEntry;
+
+  /**
+   * Payment Status to be updated.
+   */
+  InternalPaymentStatus paymentStatus;
+
+  /**
+   * ID of payment in GOV.UK PAY.
+   */
+  String externalPaymentId;
+
+  /**
+   * Provided Case Reference.
+   */
+  String caseReference;
+}

--- a/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
+++ b/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
@@ -1,0 +1,100 @@
+package uk.gov.caz.psr.service;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.caz.psr.model.VehicleEntrantPayment;
+import uk.gov.caz.psr.model.VehicleEntrantPaymentStatusUpdate;
+import uk.gov.caz.psr.repository.VehicleEntrantPaymentRepository;
+import uk.gov.caz.psr.service.exception.MissingVehicleEntrantPaymentException;
+
+/**
+ * A service which updates {@code paymentStatus} for all found {@link VehicleEntrantPayment}.
+ */
+@Service
+@Slf4j
+@AllArgsConstructor
+public class PaymentStatusUpdateService {
+
+  private final VehicleEntrantPaymentRepository vehicleEntrantPaymentRepository;
+
+  /**
+   * Process update of the {@link VehicleEntrantPayment} with provided details.
+   *
+   * @param vehicleEntrantPaymentStatusUpdates list of {@link VehicleEntrantPaymentStatusUpdate}
+   *                                           which contains data to find and update {@link
+   *                                           VehicleEntrantPayment}.
+   */
+  public void processUpdate(
+      List<VehicleEntrantPaymentStatusUpdate> vehicleEntrantPaymentStatusUpdates) {
+    Preconditions.checkNotNull(vehicleEntrantPaymentStatusUpdates,
+        "vehicleEntrantPaymentStatusUpdates cannot be null");
+
+    List<VehicleEntrantPayment> vehicleEntrantPayments = prepareVehicleEntrantPayments(
+        vehicleEntrantPaymentStatusUpdates);
+    vehicleEntrantPaymentRepository.update(vehicleEntrantPayments);
+  }
+
+  /**
+   * Builds list of {@link VehicleEntrantPayment} to be updated.
+   *
+   * @param vehicleEntrantPaymentStatusUpdates list of {@link VehicleEntrantPaymentStatusUpdate}
+   *                                           which contains data to find and update {@link
+   *                                           VehicleEntrantPayment}.
+   */
+  private List<VehicleEntrantPayment> prepareVehicleEntrantPayments(
+      List<VehicleEntrantPaymentStatusUpdate> vehicleEntrantPaymentStatusUpdates) {
+
+    return vehicleEntrantPaymentStatusUpdates.stream()
+        .map(this::prepareVehicleEntrantPayment)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Builds {@link VehicleEntrantPayment} with updated status.
+   *
+   * @param vehicleEntrantPaymentStatusUpdate {@link VehicleEntrantPaymentStatusUpdate} which
+   *                                          contains data to find and update {@link
+   *                                          VehicleEntrantPayment}.
+   */
+  private VehicleEntrantPayment prepareVehicleEntrantPayment(
+      VehicleEntrantPaymentStatusUpdate vehicleEntrantPaymentStatusUpdate) {
+    VehicleEntrantPayment vehicleEntrantPayment = loadVehicleEntrantPayment(
+        vehicleEntrantPaymentStatusUpdate).orElseThrow(
+          () -> new MissingVehicleEntrantPaymentException("VehicleEntrantPayment not found for: "
+              + vehicleEntrantPaymentStatusUpdate));
+
+    return vehicleEntrantPayment.toBuilder()
+        .internalPaymentStatus(vehicleEntrantPaymentStatusUpdate.getPaymentStatus())
+        .build();
+  }
+
+  /**
+   * Loads {@link VehicleEntrantPayment} from the repository for the provided details.
+   *
+   * @param vehicleEntrantPaymentStatusUpdate {@link VehicleEntrantPaymentStatusUpdate} which
+   *                                          contains data to find and update {@link
+   *                                          VehicleEntrantPayment}.
+   */
+  private Optional<VehicleEntrantPayment> loadVehicleEntrantPayment(
+      VehicleEntrantPaymentStatusUpdate vehicleEntrantPaymentStatusUpdate) {
+
+    if (Strings.isNullOrEmpty(vehicleEntrantPaymentStatusUpdate.getExternalPaymentId())) {
+      return vehicleEntrantPaymentRepository
+          .findOnePaidByVrnAndCazEntryDate(vehicleEntrantPaymentStatusUpdate.getCleanAirZoneId(),
+              vehicleEntrantPaymentStatusUpdate.getVrn(),
+              vehicleEntrantPaymentStatusUpdate.getDateOfCazEntry());
+    }
+    return vehicleEntrantPaymentRepository
+        .findOnePaidByCazEntryDateAndExternalPaymentId(
+            vehicleEntrantPaymentStatusUpdate.getCleanAirZoneId(),
+            vehicleEntrantPaymentStatusUpdate.getDateOfCazEntry(),
+            vehicleEntrantPaymentStatusUpdate.getExternalPaymentId());
+
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/service/exception/MissingVehicleEntrantPaymentException.java
+++ b/src/main/java/uk/gov/caz/psr/service/exception/MissingVehicleEntrantPaymentException.java
@@ -1,0 +1,13 @@
+package uk.gov.caz.psr.service.exception;
+
+/**
+ * Exception class which will be used to throw exception when {@link
+ * uk.gov.caz.psr.model.VehicleEntrantPayment} was not found in
+ * {@code VehicleEntrantPaymentRepository} findOne methods.
+ */
+public class MissingVehicleEntrantPaymentException extends RuntimeException {
+
+  public MissingVehicleEntrantPaymentException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +31,7 @@ import uk.gov.caz.correlationid.Constants;
 import uk.gov.caz.psr.dto.ChargeSettlementPaymentStatus;
 import uk.gov.caz.psr.dto.PaymentStatusUpdateDetails;
 import uk.gov.caz.psr.dto.PaymentStatusUpdateRequest;
+import uk.gov.caz.psr.service.PaymentStatusUpdateService;
 import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusUpdateDetailsFactory;
 
 @ContextConfiguration(classes = {GlobalExceptionHandlerConfiguration.class, Configuration.class,
@@ -42,6 +44,9 @@ class ChargeSettlementControllerTest {
 
   @Autowired
   private ObjectMapper objectMapper;
+
+  @MockBean
+  private PaymentStatusUpdateService paymentStatusUpdateService;
 
   private static final String ANY_VALID_VRN = "DL76MWX";
   private static final String ANY_VALID_DATE_STRING = LocalDate.now().toString();
@@ -168,7 +173,8 @@ class ChargeSettlementControllerTest {
           .content(payload)
           .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
           .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
+          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .header(Headers.X_API_KEY, UUID.randomUUID()))
           .andExpect(status().isOk());
     }
 

--- a/src/test/java/uk/gov/caz/psr/repository/VehicleEntrantPaymentRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/VehicleEntrantPaymentRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -191,7 +192,21 @@ class VehicleEntrantPaymentRepositoryTest {
       assertThat(throwable).isInstanceOf(IllegalStateException.class)
           .hasMessage("More than one VehicleEntrantPayment found");
     }
+
+    @Test
+    public void shouldReturnOptionalEmptyWhenNoVehicleEntrantPaymentFound() {
+      // given
+      mockNoItemsFoundInDatabaseForFindOneWithVrn();
+
+      // when
+      Optional<VehicleEntrantPayment> response = vehicleEntrantPaymentRepository
+          .findOnePaidByVrnAndCazEntryDate(UUID.randomUUID(), "VRN", LocalDate.now());
+
+      // then
+      assertThat(response).isEqualTo(Optional.empty());
+    }
   }
+
   @Nested
   class FindOnePaidByCazEntryDateAndExternalPaymentId {
 
@@ -229,9 +244,6 @@ class VehicleEntrantPaymentRepositoryTest {
 
     @Test
     public void shouldThrowNIllegalArgumentExceptionWhenExternalPaymentIsEmpty() {
-      // given
-      String vrn = null;
-
       // when
       Throwable throwable = catchThrowable(
           () -> vehicleEntrantPaymentRepository
@@ -251,11 +263,26 @@ class VehicleEntrantPaymentRepositoryTest {
       // when
       Throwable throwable = catchThrowable(
           () -> vehicleEntrantPaymentRepository
-              .findOnePaidByCazEntryDateAndExternalPaymentId(UUID.randomUUID(), LocalDate.now(), "test"));
+              .findOnePaidByCazEntryDateAndExternalPaymentId(UUID.randomUUID(), LocalDate.now(),
+                  "test"));
 
       // then
       assertThat(throwable).isInstanceOf(IllegalStateException.class)
           .hasMessage("More than one VehicleEntrantPayment found");
+    }
+
+    @Test
+    public void shouldReturnOptionalEmptyWhenNoVehicleEntrantPaymentFound() {
+      // given
+      mockNoItemsFoundInDatabaseForFindOneWithExternalPayment();
+
+      // when
+      Optional<VehicleEntrantPayment> response = vehicleEntrantPaymentRepository
+          .findOnePaidByCazEntryDateAndExternalPaymentId(UUID.randomUUID(), LocalDate.now(),
+              "test");
+
+      // then
+      assertThat(response).isEqualTo(Optional.empty());
     }
   }
 
@@ -277,5 +304,21 @@ class VehicleEntrantPaymentRepositoryTest {
         any(PreparedStatementSetter.class),
         any(VehicleEntrantPaymentRowMapper.class)
     )).thenReturn(vehicleEntrantPayments);
+  }
+
+  private void mockNoItemsFoundInDatabaseForFindOneWithExternalPayment() {
+    when(jdbcTemplate.query(
+        eq(VehicleEntrantPaymentRepository.SELECT_BY_EXTERNAL_PAYMENT_VRN_AND_STATUS_SQL),
+        any(PreparedStatementSetter.class),
+        any(VehicleEntrantPaymentRowMapper.class)
+    )).thenReturn(Collections.emptyList());
+  }
+
+  private void mockNoItemsFoundInDatabaseForFindOneWithVrn() {
+    when(jdbcTemplate.query(
+        eq(VehicleEntrantPaymentRepository.SELECT_BY_VRN_CAZ_ENTRY_DATE_AND_STATUS_SQL),
+        any(PreparedStatementSetter.class),
+        any(VehicleEntrantPaymentRowMapper.class)
+    )).thenReturn(Collections.emptyList());
   }
 }

--- a/src/test/java/uk/gov/caz/psr/service/PaymentStatusUpdateServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/PaymentStatusUpdateServiceTest.java
@@ -1,0 +1,99 @@
+package uk.gov.caz.psr.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.caz.psr.model.VehicleEntrantPayment;
+import uk.gov.caz.psr.model.VehicleEntrantPaymentStatusUpdate;
+import uk.gov.caz.psr.repository.VehicleEntrantPaymentRepository;
+import uk.gov.caz.psr.service.exception.MissingVehicleEntrantPaymentException;
+import uk.gov.caz.psr.util.TestObjectFactory.VehicleEntrantPaymentStatusUpdates;
+import uk.gov.caz.psr.util.TestObjectFactory.VehicleEntrantPayments;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentStatusUpdateServiceTest {
+
+  @Mock
+  private VehicleEntrantPaymentRepository vehicleEntrantPaymentRepository;
+
+  @InjectMocks
+  private PaymentStatusUpdateService paymentStatusUpdateService;
+
+  @Test
+  public void shouldThrowNullPointerExceptionWhenProvidedListIsNull() {
+    // given
+    List<VehicleEntrantPaymentStatusUpdate> vehicleEntrantPaymentStatusUpdatesList = null;
+
+    // when
+    Throwable throwable = catchThrowable(
+        () -> paymentStatusUpdateService.processUpdate(vehicleEntrantPaymentStatusUpdatesList));
+
+    // then
+    assertThat(throwable).isInstanceOf(NullPointerException.class)
+        .hasMessage("vehicleEntrantPaymentStatusUpdates cannot be null");
+    verify(vehicleEntrantPaymentRepository, never()).update(anyList());
+  }
+
+  @Test
+  public void shouldThrowMissingVehicleEntrantPaymentExceptionWhenVehicleEntrantPaymentNotFound() {
+    // given
+    VehicleEntrantPaymentStatusUpdate anyVehicleEntrantPaymentStatusUpdate = VehicleEntrantPaymentStatusUpdates
+        .any();
+    List<VehicleEntrantPaymentStatusUpdate> vehicleEntrantPaymentStatusUpdatesList = Arrays.asList(
+        anyVehicleEntrantPaymentStatusUpdate
+    );
+    mockVehicleEntrantPaymentNotFound();
+
+    // when
+    Throwable throwable = catchThrowable(
+        () -> paymentStatusUpdateService.processUpdate(vehicleEntrantPaymentStatusUpdatesList));
+
+    // then
+    assertThat(throwable).isInstanceOf(MissingVehicleEntrantPaymentException.class)
+        .hasMessage("VehicleEntrantPayment not found for: " + anyVehicleEntrantPaymentStatusUpdate);
+    verify(vehicleEntrantPaymentRepository, never()).update(anyList());
+  }
+
+  @Test
+  public void shouldUpdateVehicleEntrantPaymentsWhenValidParams() {
+    // given
+    List<VehicleEntrantPaymentStatusUpdate> vehicleEntrantPaymentStatusUpdatesList = Arrays.asList(
+        VehicleEntrantPaymentStatusUpdates.any(), VehicleEntrantPaymentStatusUpdates.any()
+    );
+    mockVehicleEntrantPaymentFound();
+    doNothing().when(vehicleEntrantPaymentRepository).update(anyList());
+
+    // when
+    paymentStatusUpdateService.processUpdate(vehicleEntrantPaymentStatusUpdatesList);
+
+    // then
+    verify(vehicleEntrantPaymentRepository).update(anyList());
+  }
+
+  private void mockVehicleEntrantPaymentNotFound() {
+    given(vehicleEntrantPaymentRepository
+        .findOnePaidByCazEntryDateAndExternalPaymentId(any(), any(), any())).willReturn(
+        java.util.Optional.empty());
+  }
+
+  private void mockVehicleEntrantPaymentFound() {
+    VehicleEntrantPayment vehicleEntrantPayment = VehicleEntrantPayments.anyPaid();
+
+    given(vehicleEntrantPaymentRepository
+        .findOnePaidByCazEntryDateAndExternalPaymentId(any(), any(), any())).willReturn(
+        java.util.Optional.ofNullable(vehicleEntrantPayment));
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
+++ b/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
@@ -18,6 +18,7 @@ import uk.gov.caz.psr.model.Payment;
 import uk.gov.caz.psr.model.PaymentMethod;
 import uk.gov.caz.psr.model.VehicleEntrant;
 import uk.gov.caz.psr.model.VehicleEntrantPayment;
+import uk.gov.caz.psr.model.VehicleEntrantPaymentStatusUpdate;
 
 public class TestObjectFactory {
 
@@ -193,6 +194,7 @@ public class TestObjectFactory {
   }
 
   public static class VehicleEntrantPayments {
+
     public static VehicleEntrantPayment anyNotPaid() {
       return VehicleEntrantPayment.builder()
           .chargePaid(100)
@@ -262,13 +264,46 @@ public class TestObjectFactory {
           .cleanZoneId(ANY_CLEAN_AIR_ZONE);
     }
   }
+
   public static class PaymentStatusUpdateDetailsFactory {
+
     public static PaymentStatusUpdateDetails anyWithStatus(ChargeSettlementPaymentStatus status) {
       return PaymentStatusUpdateDetails.builder()
           .caseReference("Test case Reference")
           .chargeSettlementPaymentStatus(status)
           .dateOfCazEntry(LocalDate.now())
           .paymentId("TestPaymentId")
+          .build();
+    }
+
+    public static PaymentStatusUpdateDetails refundedWithDateOfCazEntry(LocalDate date) {
+      return PaymentStatusUpdateDetails.builder()
+          .caseReference("Test case Reference")
+          .chargeSettlementPaymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
+          .dateOfCazEntry(date)
+          .build();
+    }
+
+    public static PaymentStatusUpdateDetails refundedWithDateOfCazEntryAndPaymentId(
+        LocalDate date, String paymentID) {
+      return PaymentStatusUpdateDetails.builder()
+          .caseReference("Test case Reference")
+          .chargeSettlementPaymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
+          .paymentId(paymentID)
+          .dateOfCazEntry(date)
+          .build();
+    }
+  }
+
+  public static class VehicleEntrantPaymentStatusUpdates {
+    public static VehicleEntrantPaymentStatusUpdate any() {
+      return VehicleEntrantPaymentStatusUpdate.builder()
+          .caseReference("Test case Reference")
+          .externalPaymentId("test payment id")
+          .paymentStatus(InternalPaymentStatus.REFUNDED)
+          .vrn("VRN123")
+          .dateOfCazEntry(LocalDate.now())
+          .cleanAirZoneId(UUID.randomUUID())
           .build();
     }
   }


### PR DESCRIPTION
Added Service to handle PaymentStatus update for selected Vehicle Entrants
Added Unit Tests
Added Integration Tests

Handled Happy Path of the ChargeSettelment#PUT payment_status

Tested in postman:
![image](https://user-images.githubusercontent.com/998642/69330132-a9922400-0c52-11ea-8ed9-7522a6f0b3b9.png)
![image](https://user-images.githubusercontent.com/998642/69330160-b57de600-0c52-11ea-8710-e637a6957a0f.png)
