### PR TITLE
[CAZ-1429] Fixes bug with not updating case_reference in PUT payment_status update action

### DIFF
--- a/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
+++ b/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
@@ -71,6 +71,7 @@ public class PaymentStatusUpdateService {
 
     return vehicleEntrantPayment.toBuilder()
         .internalPaymentStatus(vehicleEntrantPaymentStatusUpdate.getPaymentStatus())
+        .caseReference(vehicleEntrantPaymentStatusUpdate.getCaseReference())
         .build();
   }
 

--- a/src/test/java/uk/gov/caz/psr/service/PaymentStatusUpdateServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/PaymentStatusUpdateServiceTest.java
@@ -83,10 +83,42 @@ public class PaymentStatusUpdateServiceTest {
     verify(vehicleEntrantPaymentRepository).update(anyList());
   }
 
+
+  @Test
+  public void shouldUpdateWithProvidedData() {
+    // given
+    VehicleEntrantPaymentStatusUpdate vehicleEntrantPaymentStatusUpdate = VehicleEntrantPaymentStatusUpdates
+        .any();
+    List<VehicleEntrantPaymentStatusUpdate> vehicleEntrantPaymentStatusUpdatesList = Arrays.asList(
+        vehicleEntrantPaymentStatusUpdate
+    );
+    VehicleEntrantPayment foundVehicleEntrantPayment = VehicleEntrantPayments.anyPaid();
+    mockVehicleEntrantPaymentFoundWith(foundVehicleEntrantPayment);
+    List<VehicleEntrantPayment> expectedVehicleEntrantPaymentsList = Arrays.asList(
+        foundVehicleEntrantPayment.toBuilder()
+            .caseReference(vehicleEntrantPaymentStatusUpdate.getCaseReference())
+            .internalPaymentStatus(vehicleEntrantPaymentStatusUpdate.getPaymentStatus())
+            .build()
+    );
+    doNothing().when(vehicleEntrantPaymentRepository).update(expectedVehicleEntrantPaymentsList);
+
+    // when
+    paymentStatusUpdateService.processUpdate(vehicleEntrantPaymentStatusUpdatesList);
+
+    // then
+    verify(vehicleEntrantPaymentRepository).update(expectedVehicleEntrantPaymentsList);
+  }
+
   private void mockVehicleEntrantPaymentNotFound() {
     given(vehicleEntrantPaymentRepository
         .findOnePaidByCazEntryDateAndExternalPaymentId(any(), any(), any())).willReturn(
         java.util.Optional.empty());
+  }
+
+  private void mockVehicleEntrantPaymentFoundWith(VehicleEntrantPayment vehicleEntrantPayment) {
+    given(vehicleEntrantPaymentRepository
+        .findOnePaidByCazEntryDateAndExternalPaymentId(any(), any(), any())).willReturn(
+        java.util.Optional.ofNullable(vehicleEntrantPayment));
   }
 
   private void mockVehicleEntrantPaymentFound() {


### PR DESCRIPTION
QA found a bug that they are not able to update case_reference value during payment_status update.
I've found and fixed the bug that we are not assigning it to the update objects.