### PR TITLE
[CAZ-1349] Handle Error path for PUT payment_status update endpoint

### DIFF
--- a/src/it/java/uk/gov/caz/psr/ErrorPaymentStatusUpdateTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/ErrorPaymentStatusUpdateTestIT.java
@@ -1,0 +1,243 @@
+package uk.gov.caz.psr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static uk.gov.caz.security.SecurityHeadersInjector.CACHE_CONTROL_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.CACHE_CONTROL_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.CONTENT_SECURITY_POLICY_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.CONTENT_SECURITY_POLICY_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.PRAGMA_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.PRAGMA_HEADER_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.STRICT_TRANSPORT_SECURITY_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.STRICT_TRANSPORT_SECURITY_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_CONTENT_TYPE_OPTIONS_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_CONTENT_TYPE_OPTIONS_VALUE;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_FRAME_OPTIONS_HEADER;
+import static uk.gov.caz.security.SecurityHeadersInjector.X_FRAME_OPTIONS_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.jdbc.JdbcTestUtils;
+import uk.gov.caz.correlationid.Constants;
+import uk.gov.caz.psr.annotation.FullyRunningServerIntegrationTest;
+import uk.gov.caz.psr.controller.ChargeSettlementController;
+import uk.gov.caz.psr.controller.Headers;
+import uk.gov.caz.psr.dto.PaymentStatusUpdateDetails;
+import uk.gov.caz.psr.dto.PaymentStatusUpdateRequest;
+import uk.gov.caz.psr.model.InternalPaymentStatus;
+import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusUpdateDetailsFactory;
+
+@FullyRunningServerIntegrationTest
+@Sql(scripts = "classpath:data/sql/add-payments.sql",
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:data/sql/clear-all-payments.sql",
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@Slf4j
+public class ErrorPaymentStatusUpdateTestIT {
+
+  @LocalServerPort
+  int randomServerPort;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+  @BeforeEach
+  public void startMockServer() {
+    RestAssured.port = randomServerPort;
+    RestAssured.baseURI = "http://localhost";
+    RestAssured.basePath = ChargeSettlementController.BASE_PATH +
+        ChargeSettlementController.PAYMENT_STATUS_PATH;
+  }
+
+  @Test
+  public void errorsPaymentStatusUpdateJourney() {
+    // when invalid request submitted
+    given()
+        .paymentStatusUpdateRequest(invalidPaymentStatusUpdateRequest())
+        .whenInvalidRequestSubmitted()
+        .then()
+        .noVehicleEntrantPaymentUpdatedInDatabase();
+
+    // when not able to find VehicleEntrantPayment
+    given()
+        .paymentStatusUpdateRequest(paymentStatusUpdateRequestForMissing())
+        .whenMissingVehicleEntrantPaymentSubmitted()
+        .then()
+        .noVehicleEntrantPaymentUpdatedInDatabase();
+
+    // when not unique multiple VehicleEntrantPayment found
+    given()
+        .paymentStatusUpdateRequest(paymentStatusUpdateRequestFotNotUnique())
+        .whenNotUniqueVehicleEntrantPaymentSubmitted()
+        .then()
+        .noVehicleEntrantPaymentUpdatedInDatabase();
+  }
+
+  private PaymentStatusUpdateJourneyAssertion given() {
+    return new PaymentStatusUpdateJourneyAssertion(objectMapper, jdbcTemplate);
+  }
+
+  private PaymentStatusUpdateRequest invalidPaymentStatusUpdateRequest() {
+    return PaymentStatusUpdateRequest.builder()
+        .statusUpdates(exampleStatusUpdates())
+        .build();
+  }
+
+  private PaymentStatusUpdateRequest paymentStatusUpdateRequestForMissing() {
+    return PaymentStatusUpdateRequest.builder()
+        .vrn("INVALID")
+        .statusUpdates(exampleStatusUpdates())
+        .build();
+  }
+
+  private PaymentStatusUpdateRequest paymentStatusUpdateRequestFotNotUnique() {
+    return PaymentStatusUpdateRequest.builder()
+        .vrn("ND84VSX")
+        .statusUpdates(exampleStatusUpdates())
+        .build();
+  }
+
+  private List<PaymentStatusUpdateDetails> exampleStatusUpdates() {
+    return Arrays.asList(
+        PaymentStatusUpdateDetailsFactory.refundedWithDateOfCazEntry(LocalDate.of(2019, 11, 2))
+    );
+  }
+
+  @RequiredArgsConstructor
+  static class PaymentStatusUpdateJourneyAssertion {
+
+    private final ObjectMapper objectMapper;
+    private final JdbcTemplate jdbcTemplate;
+    private final UUID cleanAirZoneId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
+
+    private PaymentStatusUpdateRequest paymentStatusUpdateRequest;
+
+
+    public PaymentStatusUpdateJourneyAssertion paymentStatusUpdateRequest(
+        PaymentStatusUpdateRequest request) {
+      this.paymentStatusUpdateRequest = request;
+      return this;
+    }
+
+    public PaymentStatusUpdateJourneyAssertion then() {
+      return this;
+    }
+
+    public PaymentStatusUpdateJourneyAssertion whenInvalidRequestSubmitted() {
+      String correlationId = "79b7a48f-27c7-4947-bd1c-670f981843ef";
+
+      RestAssured
+          .given()
+          .accept(MediaType.APPLICATION_JSON.toString())
+          .contentType(MediaType.APPLICATION_JSON.toString())
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(Headers.X_API_KEY, cleanAirZoneId)
+          .body(toJsonString(paymentStatusUpdateRequest))
+          .when()
+          .put()
+          .then()
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(STRICT_TRANSPORT_SECURITY_HEADER, STRICT_TRANSPORT_SECURITY_VALUE)
+          .header(PRAGMA_HEADER, PRAGMA_HEADER_VALUE)
+          .header(X_CONTENT_TYPE_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_VALUE)
+          .header(X_FRAME_OPTIONS_HEADER, X_FRAME_OPTIONS_VALUE)
+          .header(CONTENT_SECURITY_POLICY_HEADER, CONTENT_SECURITY_POLICY_VALUE)
+          .header(CACHE_CONTROL_HEADER, CACHE_CONTROL_VALUE)
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .body("errors[0].vrn", equalTo(null))
+          .body("errors[0].detail", containsString("The vrn field is mandatory"));
+      return this;
+    }
+
+    public PaymentStatusUpdateJourneyAssertion whenMissingVehicleEntrantPaymentSubmitted() {
+      String correlationId = "79b7a48f-27c7-4947-bd1c-670f981843ef";
+
+      RestAssured
+          .given()
+          .accept(MediaType.APPLICATION_JSON.toString())
+          .contentType(MediaType.APPLICATION_JSON.toString())
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(Headers.X_API_KEY, cleanAirZoneId)
+          .body(toJsonString(paymentStatusUpdateRequest))
+          .when()
+          .put()
+          .then()
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(STRICT_TRANSPORT_SECURITY_HEADER, STRICT_TRANSPORT_SECURITY_VALUE)
+          .header(PRAGMA_HEADER, PRAGMA_HEADER_VALUE)
+          .header(X_CONTENT_TYPE_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_VALUE)
+          .header(X_FRAME_OPTIONS_HEADER, X_FRAME_OPTIONS_VALUE)
+          .header(CONTENT_SECURITY_POLICY_HEADER, CONTENT_SECURITY_POLICY_VALUE)
+          .header(CACHE_CONTROL_HEADER, CACHE_CONTROL_VALUE)
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .body("errors[0].vrn", equalTo(paymentStatusUpdateRequest.getVrn()))
+          .body("errors[0].detail", containsString("VehicleEntrantPayment not found"));
+      return this;
+    }
+
+    public PaymentStatusUpdateJourneyAssertion whenNotUniqueVehicleEntrantPaymentSubmitted() {
+      String correlationId = "79b7a48f-27c7-4947-bd1c-670f981843ef";
+
+      RestAssured
+          .given()
+          .accept(MediaType.APPLICATION_JSON.toString())
+          .contentType(MediaType.APPLICATION_JSON.toString())
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(Headers.X_API_KEY, cleanAirZoneId)
+          .body(toJsonString(paymentStatusUpdateRequest))
+          .when()
+          .put()
+          .then()
+          .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+          .header(STRICT_TRANSPORT_SECURITY_HEADER, STRICT_TRANSPORT_SECURITY_VALUE)
+          .header(PRAGMA_HEADER, PRAGMA_HEADER_VALUE)
+          .header(X_CONTENT_TYPE_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_VALUE)
+          .header(X_FRAME_OPTIONS_HEADER, X_FRAME_OPTIONS_VALUE)
+          .header(CONTENT_SECURITY_POLICY_HEADER, CONTENT_SECURITY_POLICY_VALUE)
+          .header(CACHE_CONTROL_HEADER, CACHE_CONTROL_VALUE)
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .body("errors[0].vrn", equalTo(paymentStatusUpdateRequest.getVrn()))
+          .body("errors[0].detail",
+              containsString("Not able to find unique VehicleEntrantPayment"));
+      return this;
+    }
+
+    @SneakyThrows
+    private String toJsonString(Object request) {
+      return objectMapper.writeValueAsString(request);
+    }
+
+    public PaymentStatusUpdateJourneyAssertion noVehicleEntrantPaymentUpdatedInDatabase() {
+      verifyNoVehicleEntrantPaymentUpdated();
+      return this;
+    }
+
+    private void verifyNoVehicleEntrantPaymentUpdated() {
+      int vehicleEntrantPaymentCount = JdbcTestUtils.countRowsInTableWhere(jdbcTemplate,
+          "vehicle_entrant_payment",
+          "caz_id = '" + cleanAirZoneId.toString() + "' AND "
+              + "vrn = '" + paymentStatusUpdateRequest.getVrn() + "' AND "
+              + "payment_status = '" + InternalPaymentStatus.REFUNDED.name() + "'");
+      assertThat(vehicleEntrantPaymentCount).isEqualTo(0);
+    }
+  }
+}

--- a/src/it/java/uk/gov/caz/psr/GetAndUpdatePaymentStatusTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/GetAndUpdatePaymentStatusTestIT.java
@@ -43,7 +43,7 @@ public class GetAndUpdatePaymentStatusTestIT {
     String correlationId = "31f69f26-fb99-11e9-8483-9fcf0b2b434f";
     mockMvc.perform(get(URL_TEMPLATE, id)
         .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .accept(MediaType.APPLICATION_JSON))
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, correlationId))
         .andExpect(status().isBadRequest());
   }
@@ -55,7 +55,7 @@ public class GetAndUpdatePaymentStatusTestIT {
     String correlationId = "542de1b5-4aab-45eb-bccc-6ec91f1d6d51";
     mockMvc.perform(get(URL_TEMPLATE, notExistingId)
         .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .accept(MediaType.APPLICATION_JSON))
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, correlationId))
         .andExpect(status().isNotFound());
   }
@@ -67,7 +67,7 @@ public class GetAndUpdatePaymentStatusTestIT {
     String correlationId = "939898b0-fb9e-11e9-8483-cb50ccd05275";
     mockMvc.perform(get(URL_TEMPLATE, paymentId)
         .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .accept(MediaType.APPLICATION_JSON))
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, correlationId))
         .andExpect(status().isNotFound());
   }

--- a/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
@@ -57,8 +57,8 @@ public class GetChargeSettlementPaymentStatusTestIT {
     String nonExistingVrn = "CAS222";
 
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
-        .contentType(MediaType.APPLICATION_JSON_UTF8)
-        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
         .header(Headers.X_API_KEY, VALID_CAZ_ID)
         .param("vrn", nonExistingVrn)
@@ -72,8 +72,8 @@ public class GetChargeSettlementPaymentStatusTestIT {
   public void shouldReturn500WhenThereAreTwoPaidPaymentStatusesWithSameVrnAndDateOfEntrance()
       throws Exception {
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
-        .contentType(MediaType.APPLICATION_JSON_UTF8)
-        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
         .header(Headers.X_API_KEY, VALID_CAZ_ID)
         .param("vrn", VALID_VRN)
@@ -85,8 +85,8 @@ public class GetChargeSettlementPaymentStatusTestIT {
   public void shouldReturn200AndPaidPaymentStatusWhenThereAreManyRecordsAndOneOfThemIsPaid()
       throws Exception {
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
-        .contentType(MediaType.APPLICATION_JSON_UTF8)
-        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
         .header(Headers.X_API_KEY, VALID_CAZ_ID)
         .param("vrn", VALID_VRN)
@@ -99,8 +99,8 @@ public class GetChargeSettlementPaymentStatusTestIT {
   @Test
   public void shouldReturn200AndTheExistingPaymentWhenThereAreNoPaid() throws Exception {
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
-        .contentType(MediaType.APPLICATION_JSON_UTF8)
-        .accept(MediaType.APPLICATION_JSON_UTF8)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
         .header(Headers.X_API_KEY, VALID_CAZ_ID)
         .param("vrn", VALID_VRN)

--- a/src/it/resources/data/sql/add-payments.sql
+++ b/src/it/resources/data/sql/add-payments.sql
@@ -2,7 +2,8 @@ INSERT INTO payment(
 	payment_id, payment_method, payment_provider_id, total_paid, payment_submitted_timestamp, payment_authorised_timestamp)
 	VALUES
 	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', '12345test', 100, now(), now()),
-	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', '54321test', 200, now(), now());
+	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', '54321test', 200, now(), now()),
+	  ('dabc1391-ff31-427a-8000-69037deb2d3a', 'CREDIT_DEBIT_CARD', '98765test', 100, now(), now());
 
 INSERT INTO vehicle_entrant_payment(
 	vehicle_entrant_payment_id, vehicle_entrant_id, payment_id, vrn, caz_id, travel_date, charge_paid, payment_status)
@@ -10,4 +11,5 @@ INSERT INTO vehicle_entrant_payment(
 	  ('43ea77cc-93cb-4df3-b731-5244c0de9cc8', null, 'b71b72a5-902f-4a16-a91d-1a4463b801db', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-01', 50, 'PAID'),
 	  ('688f8278-2f0f-4710-bb7c-6b0cca04c1bc', null, 'b71b72a5-902f-4a16-a91d-1a4463b801db', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 50, 'PAID'),
 	  ('9cc2dd1a-905e-4eaf-af85-0b14f95aab89', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 100, 'PAID'),
+	  ('00136ccf-e41b-4ce2-b044-7616aa589aa2', null, 'dabc1391-ff31-427a-8000-69037deb2d3a', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 100, 'PAID'),
 	  ('21b7049d-b978-482f-a882-4de6bb9d699c', null, 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-04', 100, 'PAID');

--- a/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.caz.psr.controller.exception.DtoValidationException;
 import uk.gov.caz.psr.dto.PaymentInfoRequest;
 import uk.gov.caz.psr.dto.PaymentInfoResponse;
 import uk.gov.caz.psr.dto.PaymentStatusRequest;
@@ -60,8 +62,11 @@ public class ChargeSettlementController implements ChargeSettlementControllerApi
 
   @Override
   public PaymentUpdateSuccessResponse updatePaymentStatus(PaymentStatusUpdateRequest request,
-      String apiKey) {
+      BindingResult bindingResult, String apiKey) {
     UUID cleanAirZoneId = UUID.fromString(apiKey);
+    if (bindingResult.hasErrors()) {
+      throw new DtoValidationException(request.getVrn(), bindingResult);
+    }
     paymentStatusUpdateService
         .processUpdate(request.toVehicleEntrantPaymentStatusUpdates(cleanAirZoneId));
     return new PaymentUpdateSuccessResponse();

--- a/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementControllerApiSpec.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiResponses;
 import javax.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -149,6 +150,6 @@ public interface ChargeSettlementControllerApiSpec {
   })
   @PutMapping(ChargeSettlementController.PAYMENT_STATUS_PATH)
   PaymentUpdateSuccessResponse updatePaymentStatus(
-      @Valid @RequestBody PaymentStatusUpdateRequest request,
+      @Valid @RequestBody PaymentStatusUpdateRequest request, BindingResult bindingResult,
       @RequestHeader(Headers.X_API_KEY) String apiKey);
 }

--- a/src/main/java/uk/gov/caz/psr/controller/ExceptionController.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ExceptionController.java
@@ -1,0 +1,75 @@
+package uk.gov.caz.psr.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import uk.gov.caz.GlobalExceptionHandler;
+import uk.gov.caz.psr.controller.exception.DtoValidationException;
+import uk.gov.caz.psr.dto.ErrorResponse;
+import uk.gov.caz.psr.dto.ErrorsResponse;
+import uk.gov.caz.psr.model.ValidationError;
+import uk.gov.caz.psr.repository.exception.NotUniqueVehicleEntrantPaymentFoundException;
+import uk.gov.caz.psr.service.exception.MissingVehicleEntrantPaymentException;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ExceptionController extends GlobalExceptionHandler {
+
+  /**
+   * Method to handle Exception while VehicleEntrantPayment was not found and failed with {@link
+   * MissingVehicleEntrantPaymentException}.
+   *
+   * @param e Exception object.
+   */
+  @ExceptionHandler(MissingVehicleEntrantPaymentException.class)
+  ResponseEntity<ErrorsResponse> handleMissingVehicleEntrantPaymentException(
+      MissingVehicleEntrantPaymentException e) {
+
+    log.info("MissingVehicleEntrantPaymentException occurred: {}", e);
+    return ResponseEntity.badRequest()
+        .body(ErrorsResponse.singleValidationErrorResponse(e.getVrn(), e.getMessage()));
+  }
+
+  /**
+   * Method to handle Exception while VehicleEntrantPayment was not found and failed with {@link
+   * NotUniqueVehicleEntrantPaymentFoundException}.
+   *
+   * @param e Exception object.
+   */
+  @ExceptionHandler(NotUniqueVehicleEntrantPaymentFoundException.class)
+  ResponseEntity<ErrorsResponse> handleNotUniqueVehicleEntrantPaymentFoundException(
+      NotUniqueVehicleEntrantPaymentFoundException e) {
+
+    log.info("NotUniqueVehicleEntrantPaymentFoundException occurred: {}", e);
+    return ResponseEntity.badRequest()
+        .body(ErrorsResponse.singleValidationErrorResponse(e.getVrn(), e.getMessage()));
+  }
+
+  /**
+   * Method to handle Exception while validation of request DTO failed with {@link
+   * DtoValidationException}.
+   *
+   * @param ex Exception object.
+   */
+  @ExceptionHandler(DtoValidationException.class)
+  public ResponseEntity<ErrorsResponse> handleValidationExceptions(DtoValidationException ex) {
+    List<ErrorResponse> errorsList = ex.getBindingResult().getAllErrors().stream()
+        .map(error -> ErrorResponse.from(
+            ValidationError.builder()
+                .vrn(ex.getVrn())
+                .field(((FieldError) error).getField())
+                .title(error.getDefaultMessage())
+                .build()
+            )
+        ).collect(Collectors.toList());
+    log.info("DtoValidationException occurred: {}", errorsList);
+    return ResponseEntity.badRequest().body(ErrorsResponse.from(errorsList));
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/controller/PaymentsControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/PaymentsControllerApiSpec.java
@@ -25,7 +25,7 @@ import uk.gov.caz.psr.dto.PaymentStatusResponse;
 
 @RequestMapping(
     value = PaymentsController.BASE_PATH,
-    produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+    produces = MediaType.APPLICATION_JSON_VALUE
 )
 public interface PaymentsControllerApiSpec {
 

--- a/src/main/java/uk/gov/caz/psr/controller/VehicleEntrantControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/VehicleEntrantControllerApiSpec.java
@@ -23,7 +23,7 @@ import uk.gov.caz.psr.dto.VehicleEntrantResponse;
  */
 @RequestMapping(
     value = VehicleEntrantController.BASE_PATH,
-    produces = MediaType.APPLICATION_JSON_UTF8_VALUE
+    produces = MediaType.APPLICATION_JSON_VALUE
 )
 public interface VehicleEntrantControllerApiSpec {
 

--- a/src/main/java/uk/gov/caz/psr/controller/exception/DtoValidationException.java
+++ b/src/main/java/uk/gov/caz/psr/controller/exception/DtoValidationException.java
@@ -1,0 +1,15 @@
+package uk.gov.caz.psr.controller.exception;
+
+import lombok.Value;
+import org.springframework.validation.BindingResult;
+
+/**
+ * Exception class which will be used to throw exception when request validation fails in charge
+ * settlement API.
+ */
+@Value
+public class DtoValidationException extends IllegalArgumentException {
+
+  String vrn;
+  BindingResult bindingResult;
+}

--- a/src/main/java/uk/gov/caz/psr/dto/ErrorResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/ErrorResponse.java
@@ -1,0 +1,52 @@
+package uk.gov.caz.psr.dto;
+
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.http.HttpStatus;
+import uk.gov.caz.psr.model.ValidationError;
+
+/**
+ * Value object that represents single error response which is returned to the client upon a call to
+ * get return error with details (vrn, title, detail, status).
+ */
+@Value
+@Builder
+public class ErrorResponse {
+
+  private static final String NO_VRN = "";
+  private static final String VALIDATION_ERROR_TITLE = "Validation error";
+
+  String vrn;
+  String title;
+  String detail;
+  int status;
+
+  /**
+   * Static factory method.
+   *
+   * @param validationError An instance of {@link ValidationError} that will be mapped to {@link
+   *                        ErrorResponse}
+   * @return an instance of {@link ErrorResponse}
+   */
+  public static ErrorResponse from(ValidationError validationError) {
+    return ErrorResponse.builder()
+        .vrn(validationError.getVrn())
+        .title(validationError.getTitle())
+        .detail(validationError.getDetail())
+        .status(HttpStatus.BAD_REQUEST.value())
+        .build();
+  }
+
+  /**
+   * Creates a validation error response, i.e. its title is fixed and equal to 'Validation error',
+   * status is equal to 400 and detail is set to the parameter.
+   */
+  public static ErrorResponse validationErrorResponseWithDetailAndVrn(String vrn, String detail) {
+    return ErrorResponse.builder()
+        .vrn(vrn)
+        .title(VALIDATION_ERROR_TITLE)
+        .detail(detail)
+        .status(HttpStatus.BAD_REQUEST.value())
+        .build();
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/dto/ErrorsResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/ErrorsResponse.java
@@ -1,0 +1,39 @@
+package uk.gov.caz.psr.dto;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+/**
+ * Value object that represents collection of errors response which are returned to the client upon
+ * a call to notify about the error.
+ */
+@Value
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorsResponse {
+
+  List<ErrorResponse> errors;
+
+  /**
+   * Method to return single errors response for provided vrn and provided details.
+   *
+   * @param vrn    Vehicle Registration Number
+   * @param detail Error details.
+   */
+  public static ErrorsResponse singleValidationErrorResponse(String vrn, String detail) {
+    ErrorResponse errorResponse = ErrorResponse
+        .validationErrorResponseWithDetailAndVrn(vrn, detail);
+    return new ErrorsResponse(Collections.singletonList(errorResponse));
+  }
+
+  /**
+   * Method to return Error Response based on provided validationErrors.
+   *
+   * @param validationErrors Validation Errors.
+   */
+  public static ErrorsResponse from(List<ErrorResponse> validationErrors) {
+    return new ErrorsResponse(validationErrors);
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateDetails.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateDetails.java
@@ -2,11 +2,12 @@ package uk.gov.caz.psr.dto;
 
 import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
-import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Value;
+import uk.gov.caz.psr.model.ValidationError;
 
 /**
  * A value object which is used as a request for updating payment status which contains payment
@@ -17,19 +18,19 @@ import lombok.Value;
 public class PaymentStatusUpdateDetails {
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.date-caz-entry}")
-  @NotNull
+  @NotNull(message = ValidationError.MANDATORY_FIELD_MISSING_ERROR)
   LocalDate dateOfCazEntry;
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.payment-status}")
-  @NotNull
+  @NotNull(message = ValidationError.MANDATORY_FIELD_MISSING_ERROR)
   ChargeSettlementPaymentStatus chargeSettlementPaymentStatus;
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.payment-id}")
-  @Max(255)
+  @Size(max = 255)
   String paymentId;
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.case-reference}")
-  @NotBlank
-  @Max(15)
+  @NotBlank(message = ValidationError.MANDATORY_FIELD_MISSING_ERROR)
+  @Size(max = 15)
   String caseReference;
 }

--- a/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateRequest.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateRequest.java
@@ -4,12 +4,14 @@ import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Value;
 import uk.gov.caz.psr.model.InternalPaymentStatus;
+import uk.gov.caz.psr.model.ValidationError;
 import uk.gov.caz.psr.model.VehicleEntrantPaymentStatusUpdate;
 
 /**
@@ -20,12 +22,13 @@ import uk.gov.caz.psr.model.VehicleEntrantPaymentStatusUpdate;
 public class PaymentStatusUpdateRequest {
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.vrn}")
-  @NotBlank
+  @NotBlank(message = ValidationError.MANDATORY_FIELD_MISSING_ERROR)
   @Size(min = 1, max = 15)
   String vrn;
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.status-updates}")
-  @NotEmpty
+  @NotEmpty(message = ValidationError.MANDATORY_FIELD_MISSING_ERROR)
+  @Valid
   List<PaymentStatusUpdateDetails> statusUpdates;
 
   /**

--- a/src/main/java/uk/gov/caz/psr/model/ValidationError.java
+++ b/src/main/java/uk/gov/caz/psr/model/ValidationError.java
@@ -1,0 +1,28 @@
+package uk.gov.caz.psr.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+
+@Builder
+@Value
+public final class ValidationError {
+
+  public static final String MANDATORY_FIELD_MISSING_ERROR = "Mandatory field missing";
+  String vrn;
+  String title;
+  String field;
+
+  public String getDetail() {
+    return "The " + field + " " + resolveMessage();
+  }
+
+  private String resolveMessage() {
+    switch (title) {
+      case MANDATORY_FIELD_MISSING_ERROR:
+        return "field is mandatory";
+      default:
+        return title;
+    }
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/repository/VehicleEntrantPaymentRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/VehicleEntrantPaymentRepository.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.caz.psr.model.InternalPaymentStatus;
 import uk.gov.caz.psr.model.VehicleEntrant;
 import uk.gov.caz.psr.model.VehicleEntrantPayment;
+import uk.gov.caz.psr.repository.exception.NotUniqueVehicleEntrantPaymentFoundException;
 
 /**
  * A class which handles managing data in {@code VEHICLE_ENTRANT_PAYMENT} table.
@@ -242,16 +243,18 @@ public class VehicleEntrantPaymentRepository {
 
   /**
    * Finds single of {@link VehicleEntrantPayment} entity for the passed params. If none is found,
-   * {@link Optional#empty()} is returned. If more then one found throws {@code RuntimeException}.
+   * {@link Optional#empty()} is returned. If more then one found throws {@link
+   * NotUniqueVehicleEntrantPaymentFoundException}.
    *
    * @param cleanZoneId  provided Clean Air Zone ID.
    * @param vrn          provided VRN number
    * @param cazEntryDate Date of entry to provided CAZ
    * @return list of found {@link VehicleEntrantPayment}.
-   * @throws NullPointerException     if {@code cleanZoneId} is null.
-   * @throws NullPointerException     if {@code cazEntryDate} is null.
-   * @throws IllegalArgumentException if {@code vrn} is empty.
-   * @throws IllegalStateException    if method found more than one VehicleEntrantPayment.
+   * @throws NullPointerException                         if {@code cleanZoneId} is null.
+   * @throws NullPointerException                         if {@code cazEntryDate} is null.
+   * @throws IllegalArgumentException                     if {@code vrn} is empty.
+   * @throws NotUniqueVehicleEntrantPaymentFoundException if method found more than one
+   *                                                      VehicleEntrantPayment.
    */
   public Optional<VehicleEntrantPayment> findOnePaidByVrnAndCazEntryDate(UUID cleanZoneId,
       String vrn, LocalDate cazEntryDate) {
@@ -270,7 +273,8 @@ public class VehicleEntrantPaymentRepository {
             ROW_MAPPER
         );
     if (results.size() > 1) {
-      throw new IllegalStateException("More than one VehicleEntrantPayment found");
+      throw new NotUniqueVehicleEntrantPaymentFoundException(vrn,
+          "Not able to find unique VehicleEntrantPayment");
     }
     if (results.isEmpty()) {
       return Optional.empty();
@@ -280,16 +284,18 @@ public class VehicleEntrantPaymentRepository {
 
   /**
    * Finds single of {@link VehicleEntrantPayment} entity for the passed params. If none is found,
-   * {@link Optional#empty()} is returned. If more then one found throws {@code RuntimeException}.
+   * {@link Optional#empty()} is returned. If more then one found throws {@link
+   * NotUniqueVehicleEntrantPaymentFoundException}.
    *
    * @param cleanZoneId       provided Clean Air Zone ID
    * @param cazEntryDate      Date of entry to provided CAZ
    * @param externalPaymentId Payment Id from GOV.UK PAY
    * @return list of found {@link VehicleEntrantPayment}.
-   * @throws NullPointerException     if {@code cleanZoneId} is null.
-   * @throws NullPointerException     if {@code cazEntryDate} is null.
-   * @throws IllegalArgumentException if {@code vrn} is empty.
-   * @throws IllegalStateException    if method found more than one VehicleEntrantPayment.
+   * @throws NullPointerException                         if {@code cleanZoneId} is null.
+   * @throws NullPointerException                         if {@code cazEntryDate} is null.
+   * @throws IllegalArgumentException                     if {@code vrn} is empty.
+   * @throws NotUniqueVehicleEntrantPaymentFoundException if method found more than one
+   *                                                      VehicleEntrantPayment.
    */
   public Optional<VehicleEntrantPayment> findOnePaidByCazEntryDateAndExternalPaymentId(
       UUID cleanZoneId, LocalDate cazEntryDate, String externalPaymentId) {
@@ -309,7 +315,8 @@ public class VehicleEntrantPaymentRepository {
             ROW_MAPPER
         );
     if (results.size() > 1) {
-      throw new IllegalStateException("More than one VehicleEntrantPayment found");
+      throw new NotUniqueVehicleEntrantPaymentFoundException(null,
+          "Not able to find unique VehicleEntrantPayment");
     }
     if (results.isEmpty()) {
       return Optional.empty();

--- a/src/main/java/uk/gov/caz/psr/repository/exception/NotUniqueVehicleEntrantPaymentFoundException.java
+++ b/src/main/java/uk/gov/caz/psr/repository/exception/NotUniqueVehicleEntrantPaymentFoundException.java
@@ -1,0 +1,14 @@
+package uk.gov.caz.psr.repository.exception;
+
+import lombok.Value;
+
+/**
+ * Exception class which will be used to throw exception when {@code
+ * VehicleEntrantPaymentRepository} found more then one VehicleEntrantPayment for FindOne methods.
+ */
+@Value
+public class NotUniqueVehicleEntrantPaymentFoundException extends RuntimeException {
+
+  String vrn;
+  String message;
+}

--- a/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
+++ b/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
@@ -66,8 +66,9 @@ public class PaymentStatusUpdateService {
       VehicleEntrantPaymentStatusUpdate vehicleEntrantPaymentStatusUpdate) {
     VehicleEntrantPayment vehicleEntrantPayment = loadVehicleEntrantPayment(
         vehicleEntrantPaymentStatusUpdate).orElseThrow(
-          () -> new MissingVehicleEntrantPaymentException("VehicleEntrantPayment not found for: "
-              + vehicleEntrantPaymentStatusUpdate));
+          () -> new MissingVehicleEntrantPaymentException(
+              vehicleEntrantPaymentStatusUpdate.getVrn(),
+              "VehicleEntrantPayment not found for: " + vehicleEntrantPaymentStatusUpdate));
 
     return vehicleEntrantPayment.toBuilder()
         .internalPaymentStatus(vehicleEntrantPaymentStatusUpdate.getPaymentStatus())

--- a/src/main/java/uk/gov/caz/psr/service/exception/MissingVehicleEntrantPaymentException.java
+++ b/src/main/java/uk/gov/caz/psr/service/exception/MissingVehicleEntrantPaymentException.java
@@ -1,13 +1,15 @@
 package uk.gov.caz.psr.service.exception;
 
+import lombok.Value;
+
 /**
  * Exception class which will be used to throw exception when {@link
- * uk.gov.caz.psr.model.VehicleEntrantPayment} was not found in
- * {@code VehicleEntrantPaymentRepository} findOne methods.
+ * uk.gov.caz.psr.model.VehicleEntrantPayment} was not found in {@code
+ * VehicleEntrantPaymentRepository} findOne methods.
  */
-public class MissingVehicleEntrantPaymentException extends RuntimeException {
+@Value
+public class MissingVehicleEntrantPaymentException extends IllegalArgumentException {
 
-  public MissingVehicleEntrantPaymentException(String message) {
-    super(message);
-  }
+  String vrn;
+  String message;
 }

--- a/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.caz.psr.controller;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -43,7 +44,7 @@ import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusUpdateDetailsFactory;
 import uk.gov.caz.psr.util.VehicleEntrantPaymentInfoConverter;
 
 @ContextConfiguration(classes = {GlobalExceptionHandlerConfiguration.class, Configuration.class,
-    ChargeSettlementController.class})
+    ChargeSettlementController.class, ExceptionController.class})
 @WebMvcTest
 class ChargeSettlementControllerTest {
 
@@ -77,8 +78,8 @@ class ChargeSettlementControllerTest {
 
       mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
           .content(payload)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.message")
               .value("Missing request header 'X-Correlation-ID'"));
@@ -88,8 +89,8 @@ class ChargeSettlementControllerTest {
     public void shouldReturn400StatusCodeWhenVrnIsMissing() throws Exception {
       mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8)
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
           .param("dateOfCazEntry", ANY_VALID_DATE_STRING))
           .andExpect(status().isBadRequest());
     }
@@ -98,8 +99,8 @@ class ChargeSettlementControllerTest {
     public void shouldReturn400StatusWhenDateOfCazEntryIsMissing() throws Exception {
       mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .contentType(MediaType.APPLICATION_JSON_UTF8)
-          .accept(MediaType.APPLICATION_JSON_UTF8)
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
           .param("vrn", ANY_VALID_VRN))
           .andExpect(status().isBadRequest());
     }
@@ -109,8 +110,8 @@ class ChargeSettlementControllerTest {
     public void shouldReturn400StatusCodeWhenVrnIsInvalid(String vrn) throws Exception {
       mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8)
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
           .param("vrn", vrn)
           .param("dateOfCazEntry", ANY_VALID_DATE_STRING))
           .andExpect(status().isBadRequest());
@@ -128,8 +129,8 @@ class ChargeSettlementControllerTest {
       mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
           .header(Headers.X_API_KEY, UUID.randomUUID())
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8)
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
           .param("vrn", ANY_VALID_VRN)
           .param("dateOfCazEntry", ANY_VALID_DATE_STRING))
           .andExpect(status().isOk());
@@ -145,8 +146,9 @@ class ChargeSettlementControllerTest {
 
       mockMvc.perform(put(PAYMENT_STATUS_PUT_PATH)
           .content(payload)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .header(Headers.X_API_KEY, UUID.randomUUID()))
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.message")
               .value("Missing request header 'X-Correlation-ID'"));
@@ -159,7 +161,8 @@ class ChargeSettlementControllerTest {
       mockMvc.perform(post(PAYMENT_STATUS_PUT_PATH)
           .content(payload)
           .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+          .accept(MediaType.APPLICATION_JSON)
+          .header(Headers.X_API_KEY, UUID.randomUUID()))
           .andExpect(status().isMethodNotAllowed());
     }
 
@@ -169,10 +172,28 @@ class ChargeSettlementControllerTest {
 
       mockMvc.perform(put(PAYMENT_STATUS_PUT_PATH)
           .content(payload)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-          .andExpect(status().isBadRequest());
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .header(Headers.X_API_KEY, UUID.randomUUID()))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.errors[*].title").value(hasItem("Mandatory field missing")))
+          .andExpect(jsonPath("$.errors[*].detail").value(hasItem("The vrn field is mandatory")));
+    }
+
+    @Test
+    public void invalidVrnShouldResultIn400() throws Exception {
+      String payload = requestWithVrn("TOO_LONG_VRN_1234567890");
+
+      mockMvc.perform(put(PAYMENT_STATUS_PUT_PATH)
+          .content(payload)
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .header(Headers.X_API_KEY, UUID.randomUUID()))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.errors[0].title").value("size must be between 1 and 15"))
+          .andExpect(jsonPath("$.errors[0].detail").value("The vrn size must be between 1 and 15"));
     }
 
     @Test
@@ -181,10 +202,30 @@ class ChargeSettlementControllerTest {
 
       mockMvc.perform(put(PAYMENT_STATUS_PUT_PATH)
           .content(payload)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-          .andExpect(status().isBadRequest());
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .header(Headers.X_API_KEY, UUID.randomUUID()))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.errors[0].title").value("Mandatory field missing"))
+          .andExpect(jsonPath("$.errors[0].detail").value("The statusUpdates field is mandatory"));
+    }
+
+    @Test
+    public void invalidStatusUpdatesShouldResultIn400() throws Exception {
+      String payload = requestWithStatusUpdates(
+          Arrays.asList(PaymentStatusUpdateDetailsFactory.anyInvalid()));
+
+      mockMvc.perform(put(PAYMENT_STATUS_PUT_PATH)
+          .content(payload)
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .header(Headers.X_API_KEY, UUID.randomUUID()))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.errors[0].title").value("Mandatory field missing"))
+          .andExpect(jsonPath("$.errors[0].detail")
+              .value("The statusUpdates[0].caseReference field is mandatory"));
     }
 
     @Test
@@ -193,8 +234,8 @@ class ChargeSettlementControllerTest {
 
       mockMvc.perform(put(PAYMENT_STATUS_PUT_PATH)
           .content(payload)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
           .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
           .header(Headers.X_API_KEY, UUID.randomUUID()))
           .andExpect(status().isOk());

--- a/src/test/java/uk/gov/caz/psr/controller/PaymentsControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/PaymentsControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.caz.GlobalExceptionHandlerConfiguration;
 import uk.gov.caz.correlationid.Configuration;
+import uk.gov.caz.psr.controller.exception.DtoValidationException;
 import uk.gov.caz.psr.dto.InitiatePaymentRequest;
 import uk.gov.caz.psr.model.Payment;
 import uk.gov.caz.psr.repository.ExternalPaymentsRepository;
@@ -63,8 +64,8 @@ class PaymentsControllerTest {
 
     mockMvc.perform(post(BASE_PATH)
         .content(payload)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message")
             .value("Missing request header 'X-Correlation-ID'"));
@@ -77,8 +78,8 @@ class PaymentsControllerTest {
 
     mockMvc.perform(post(BASE_PATH)
         .content(payload)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
         .andExpect(status().isBadRequest());
     verify(initiatePaymentService, never()).createPayment(any());
@@ -90,8 +91,8 @@ class PaymentsControllerTest {
 
     mockMvc.perform(post(BASE_PATH)
         .content(payload)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
         .andExpect(status().isBadRequest());
     verify(initiatePaymentService, never()).createPayment(any());
@@ -103,8 +104,8 @@ class PaymentsControllerTest {
 
     mockMvc.perform(post(BASE_PATH)
         .content(payload)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
         .andExpect(status().isBadRequest());
     verify(initiatePaymentService, never()).createPayment(any());
@@ -116,8 +117,8 @@ class PaymentsControllerTest {
 
     mockMvc.perform(post(BASE_PATH)
         .content(payload)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
         .andExpect(status().isBadRequest());
     verify(initiatePaymentService, never()).createPayment(any());
@@ -134,8 +135,8 @@ class PaymentsControllerTest {
 
     mockMvc.perform(post(BASE_PATH)
         .content(payload)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
         .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.paymentId").value(successfullyCreatedPayment.getId().toString()))

--- a/src/test/java/uk/gov/caz/psr/controller/VehicleEntrantControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/VehicleEntrantControllerTest.java
@@ -63,8 +63,8 @@ class VehicleEntrantControllerTest {
       mockMvc.perform(post(PATH)
           .content(payload)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest())
           .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID));
       // TODO add assertions for a message
@@ -79,8 +79,8 @@ class VehicleEntrantControllerTest {
       mockMvc.perform(post(PATH)
           .content(payload)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest())
           .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID));
       // TODO add assertions for a message
@@ -95,8 +95,8 @@ class VehicleEntrantControllerTest {
       mockMvc.perform(post(PATH)
           .content(payload)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest())
           .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID));
       // TODO add assertions for a message
@@ -112,8 +112,8 @@ class VehicleEntrantControllerTest {
       mockMvc.perform(post(PATH)
           .content(payload)
           .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-          .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-          .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+          .contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest())
           .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID));
       // TODO add assertions for a message
@@ -132,8 +132,8 @@ class VehicleEntrantControllerTest {
     mockMvc.perform(post(PATH)
         .content(payload)
         .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
         .andExpect(jsonPath("$.status").value(InternalPaymentStatus.NOT_PAID.name()));
@@ -151,8 +151,8 @@ class VehicleEntrantControllerTest {
     mockMvc.perform(post(PATH)
         .content(payload)
         .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
-        .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE))
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
         .andExpect(jsonPath("$.status").value(InternalPaymentStatus.PAID.name()));

--- a/src/test/java/uk/gov/caz/psr/repository/VehicleEntrantPaymentRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/VehicleEntrantPaymentRepositoryTest.java
@@ -22,6 +22,7 @@ import org.springframework.jdbc.core.PreparedStatementSetter;
 import uk.gov.caz.psr.model.VehicleEntrant;
 import uk.gov.caz.psr.model.VehicleEntrantPayment;
 import uk.gov.caz.psr.repository.VehicleEntrantPaymentRepository.VehicleEntrantPaymentRowMapper;
+import uk.gov.caz.psr.repository.exception.NotUniqueVehicleEntrantPaymentFoundException;
 import uk.gov.caz.psr.util.TestObjectFactory.Payments;
 import uk.gov.caz.psr.util.TestObjectFactory.VehicleEntrantPayments;
 
@@ -189,8 +190,8 @@ class VehicleEntrantPaymentRepositoryTest {
               .findOnePaidByVrnAndCazEntryDate(UUID.randomUUID(), "VRN", LocalDate.now()));
 
       // then
-      assertThat(throwable).isInstanceOf(IllegalStateException.class)
-          .hasMessage("More than one VehicleEntrantPayment found");
+      assertThat(throwable).isInstanceOf(NotUniqueVehicleEntrantPaymentFoundException.class)
+          .hasMessage("Not able to find unique VehicleEntrantPayment");
     }
 
     @Test
@@ -267,8 +268,8 @@ class VehicleEntrantPaymentRepositoryTest {
                   "test"));
 
       // then
-      assertThat(throwable).isInstanceOf(IllegalStateException.class)
-          .hasMessage("More than one VehicleEntrantPayment found");
+      assertThat(throwable).isInstanceOf(NotUniqueVehicleEntrantPaymentFoundException.class)
+          .hasMessage("Not able to find unique VehicleEntrantPayment");
     }
 
     @Test

--- a/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
+++ b/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
@@ -271,7 +271,7 @@ public class TestObjectFactory {
 
     public static PaymentStatusUpdateDetails anyWithStatus(ChargeSettlementPaymentStatus status) {
       return PaymentStatusUpdateDetails.builder()
-          .caseReference("Test case Reference")
+          .caseReference("CaseReference")
           .chargeSettlementPaymentStatus(status)
           .dateOfCazEntry(LocalDate.now())
           .paymentId("TestPaymentId")
@@ -280,7 +280,7 @@ public class TestObjectFactory {
 
     public static PaymentStatusUpdateDetails refundedWithDateOfCazEntry(LocalDate date) {
       return PaymentStatusUpdateDetails.builder()
-          .caseReference("Test case Reference")
+          .caseReference("CaseReference")
           .chargeSettlementPaymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
           .dateOfCazEntry(date)
           .build();
@@ -289,19 +289,28 @@ public class TestObjectFactory {
     public static PaymentStatusUpdateDetails refundedWithDateOfCazEntryAndPaymentId(
         LocalDate date, String paymentID) {
       return PaymentStatusUpdateDetails.builder()
-          .caseReference("Test case Reference")
+          .caseReference("CaseReference")
           .chargeSettlementPaymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
           .paymentId(paymentID)
           .dateOfCazEntry(date)
           .build();
     }
+
+    public static PaymentStatusUpdateDetails anyInvalid() {
+      return PaymentStatusUpdateDetails.builder()
+          .chargeSettlementPaymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
+          .paymentId("paymentID")
+          .dateOfCazEntry(LocalDate.now())
+          .build();
+    }
+
   }
 
   public static class VehicleEntrantPaymentStatusUpdates {
 
     public static VehicleEntrantPaymentStatusUpdate any() {
       return VehicleEntrantPaymentStatusUpdate.builder()
-          .caseReference("Test case Reference")
+          .caseReference("CaseReference")
           .externalPaymentId("test payment id")
           .paymentStatus(InternalPaymentStatus.REFUNDED)
           .vrn("VRN123")


### PR DESCRIPTION
Added support for Error path in PUT charge_settelment#paument_status action. 
Added support for Request validation errors in response. 
Handled all possible errors
Added tests. 