### PR TITLE
CAZ-1423 Add a null-check for paymentSubmittedTimestamp when returnin…

### DIFF
--- a/src/main/java/uk/gov/caz/psr/repository/ExternalPaymentsRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/ExternalPaymentsRepository.java
@@ -92,7 +92,6 @@ public class ExternalPaymentsRepository {
           .externalId(responseBody.getPaymentId())
           .submittedTimestamp(LocalDateTime.now())
           .externalPaymentStatus(externalPaymentStatus)
-          .submittedTimestamp(LocalDateTime.now())
           .nextUrl(responseBody.getLinks().getNextUrl().getHref())
           .build();
     } catch (RestClientException e) {

--- a/src/main/java/uk/gov/caz/psr/util/VehicleEntrantPaymentInfoConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/VehicleEntrantPaymentInfoConverter.java
@@ -4,6 +4,8 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.Preconditions;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -78,11 +80,18 @@ public class VehicleEntrantPaymentInfoConverter {
   private SinglePaymentInfo toSinglePaymentInfo(PaymentInfo paymentInfo,
       List<VehicleEntrantPaymentInfo> entrantPaymentInfoList) {
     return SinglePaymentInfo.builder()
-        .paymentDate(paymentInfo.getSubmittedTimestamp().toLocalDate())
+        .paymentDate(toLocalDate(paymentInfo.getSubmittedTimestamp()))
         .paymentProviderId(paymentInfo.getExternalId())
         .totalPaid(currencyFormatter.parsePenniesToBigDecimal(paymentInfo.getTotalPaid()))
         .lineItems(toVehicleEntrantPayments(entrantPaymentInfoList))
         .build();
+  }
+
+  /**
+   * Maps the provided {@code timestamp} to a date provided it is non null. Returns null otherwise.
+   */
+  private LocalDate toLocalDate(LocalDateTime timestamp) {
+    return timestamp == null ? null : timestamp.toLocalDate();
   }
 
   /**


### PR DESCRIPTION
…g data for payment-info endpoint

`paymentSubmittedTimestamp` is set to a non-null value once the call to gov uk pay is successfully completed. Otherwise it is set to null. The previous logic did not take this into account, hence the need to introduce this fix.