### PR TITLE
NON-JIRA Normalise VRN when saving and querying by charge settlement …

### DIFF
--- a/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -87,8 +89,15 @@ public class GetChargeSettlementPaymentStatusTestIT {
             jsonPath("$.errors[0].detail").value("More than one paid VehicleEntrantPayment found"));
   }
 
-  @Test
-  public void shouldReturn200AndPaidPaymentStatusWhenThereAreManyRecordsAndOneOfThemIsPaid()
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ND84VSX", // existing
+      "Nd84vSX", "nD84vsX", // with changed capitalisation
+      "ND 84 VSX", "  ND84V S X ", "N D8   4VSX", // with whitespaces
+      "N D8  4v SX " // with whitespaces and changed capitalisation
+  })
+  public void shouldReturn200AndPaidPaymentStatusWhenThereAreManyRecordsAndOneOfThemIsPaid(
+      String vrn)
       throws Exception {
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
         .contentType(MediaType.APPLICATION_JSON)
@@ -96,22 +105,28 @@ public class GetChargeSettlementPaymentStatusTestIT {
         .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
         .header(Headers.TIMESTAMP, LocalDateTime.now())
         .header(Headers.X_API_KEY, VALID_CAZ_ID)
-        .param("vrn", VALID_VRN)
+        .param("vrn", vrn)
         .param("dateOfCazEntry", VALID_DATE_WITH_DIFFERENT_STATUSES))
         .andExpect(status().isOk())
         .andExpect(content().json(
             getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE, VALID_EXTERNAL_ID)));
   }
 
-  @Test
-  public void shouldReturn200AndTheExistingPaymentWhenThereAreNoPaid() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ND84VSX", // existing
+      "Nd84vSX", "nD84vsX", // with changed capitalisation
+      "ND 84 VSX", "  ND84V S X ", "N D8   4VSX", // with whitespaces
+      "N D8  4v SX " // with whitespaces and changed capitalisation
+  })
+  public void shouldReturn200AndTheExistingPaymentWhenThereAreNoPaid(String vrn) throws Exception {
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
         .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
         .header(Headers.TIMESTAMP, LocalDateTime.now())
         .header(Headers.X_API_KEY, VALID_CAZ_ID)
-        .param("vrn", VALID_VRN)
+        .param("vrn", vrn)
         .param("dateOfCazEntry", VALID_DATE_WITH_STATUSES_WHICH_IS_DIFFERENT_THAN_PAID))
         .andExpect(status().isOk())
         .andExpect(content().json(

--- a/src/it/java/uk/gov/caz/psr/SuccessPaymentStatusUpdateTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/SuccessPaymentStatusUpdateTestIT.java
@@ -25,7 +25,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -67,10 +68,16 @@ public class SuccessPaymentStatusUpdateTestIT {
         ChargeSettlementController.PAYMENT_STATUS_PATH;
   }
 
-  @Test
-  public void successPaymentStatusUpdateJourney() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ND84VSX",
+      "Nd84vSX", "nD84vsX",
+      "ND 84 VSX", "  ND84V S X ", "N D8   4VSX",
+      "N D8  4v SX "
+  })
+  public void successPaymentStatusUpdateJourney(String vrn) {
     given()
-        .paymentStatusUpdateRequest(paymentStatusUpdateRequest())
+        .paymentStatusUpdateRequest(paymentStatusUpdateRequest(vrn))
         .whenSubmitted()
         .then()
         .vehicleEntrantPaymentsAreUpdatedInTheDatabse();
@@ -80,9 +87,9 @@ public class SuccessPaymentStatusUpdateTestIT {
     return new PaymentStatusUpdateJourneyAssertion(objectMapper, jdbcTemplate);
   }
 
-  private PaymentStatusUpdateRequest paymentStatusUpdateRequest() {
+  private PaymentStatusUpdateRequest paymentStatusUpdateRequest(String vrn) {
     return PaymentStatusUpdateRequest.builder()
-        .vrn("ND84VSX")
+        .vrn(vrn)
         .statusUpdates(validStatusUpdates())
         .build();
   }
@@ -154,7 +161,7 @@ public class SuccessPaymentStatusUpdateTestIT {
       int vehicleEntrantCount = JdbcTestUtils.countRowsInTableWhere(jdbcTemplate,
           "vehicle_entrant_payment",
           "caz_id = '" + cleanAirZoneId.toString() + "' AND "
-              + "vrn = '" + paymentStatusUpdateRequest.getVrn() + "' AND "
+              + "vrn = 'ND84VSX' AND "
               + "payment_status = '" + InternalPaymentStatus.REFUNDED.name() + "'");
       assertThat(vehicleEntrantCount).isEqualTo(2);
     }

--- a/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateRequest.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateRequest.java
@@ -1,5 +1,7 @@
 package uk.gov.caz.psr.dto;
 
+import static uk.gov.caz.psr.util.AttributesNormaliser.normalizeVrn;
+
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import java.util.UUID;
@@ -49,7 +51,7 @@ public class PaymentStatusUpdateRequest {
       UUID cleanAirZoneId, PaymentStatusUpdateDetails paymentStatusUpdateDetail) {
     return VehicleEntrantPaymentStatusUpdate.builder()
         .cleanAirZoneId(cleanAirZoneId)
-        .vrn(vrn)
+        .vrn(normalizeVrn(vrn))
         .dateOfCazEntry(paymentStatusUpdateDetail.getDateOfCazEntry())
         .paymentStatus(InternalPaymentStatus
             .valueOf(paymentStatusUpdateDetail.getChargeSettlementPaymentStatus().name()))

--- a/src/main/java/uk/gov/caz/psr/model/PaymentInfoRequestAttributes.java
+++ b/src/main/java/uk/gov/caz/psr/model/PaymentInfoRequestAttributes.java
@@ -1,0 +1,20 @@
+package uk.gov.caz.psr.model;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * A class which holds attributes related for handling payment-info request.
+ */
+@Builder
+@Value
+public class PaymentInfoRequestAttributes {
+  String externalPaymentId;
+
+  String vrn;
+
+  LocalDate fromDatePaidFor;
+
+  LocalDate toDatePaidFor;
+}

--- a/src/main/java/uk/gov/caz/psr/service/ChargeSettlementPaymentInfoService.java
+++ b/src/main/java/uk/gov/caz/psr/service/ChargeSettlementPaymentInfoService.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.PaymentInfo;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 import uk.gov.caz.psr.repository.jpa.VehicleEntrantPaymentInfoRepository;
@@ -26,15 +26,15 @@ public class ChargeSettlementPaymentInfoService {
   /**
    * Method which filter payments based on PaymentInfoRequest.
    *
-   * @param paymentInfoRequest {@link PaymentInfoRequest}
+   * @param attributes {@link PaymentInfoRequestAttributes}
    * @param cazId for payment
    * @return  list of {@link PaymentInfo}
    */
-  public List<VehicleEntrantPaymentInfo> findPaymentInfo(PaymentInfoRequest paymentInfoRequest,
+  public List<VehicleEntrantPaymentInfo> findPaymentInfo(PaymentInfoRequestAttributes attributes,
       UUID cazId) {
     Specification<VehicleEntrantPaymentInfo> specification = specifications.stream()
-        .filter(paymentInfoSpecification -> paymentInfoSpecification.shouldUse(paymentInfoRequest))
-        .map(paymentInfoSpecification -> paymentInfoSpecification.create(paymentInfoRequest))
+        .filter(paymentInfoSpecification -> paymentInfoSpecification.shouldUse(attributes))
+        .map(paymentInfoSpecification -> paymentInfoSpecification.create(attributes))
         .reduce(CazIdSpecification.forCaz(cazId), Specification::and);
 
     return vehicleEntrantPaymentInfoRepository.findAll(specification);

--- a/src/main/java/uk/gov/caz/psr/service/InitiatePaymentService.java
+++ b/src/main/java/uk/gov/caz/psr/service/InitiatePaymentService.java
@@ -1,5 +1,7 @@
 package uk.gov.caz.psr.service;
 
+import static uk.gov.caz.psr.util.AttributesNormaliser.normalizeVrn;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -69,7 +71,7 @@ public class InitiatePaymentService {
   private VehicleEntrantPayment toVehicleEntrantPayment(LocalDate travelDate,
       InitiatePaymentRequest request, int chargePerDay) {
     return VehicleEntrantPayment.builder()
-        .vrn(request.getVrn())
+        .vrn(normalizeVrn(request.getVrn()))
         .cleanZoneId(request.getCleanAirZoneId())
         .travelDate(travelDate)
         .chargePaid(chargePerDay)

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecification.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecification.java
@@ -1,7 +1,7 @@
 package uk.gov.caz.psr.service.paymentinfo;
 
 import org.springframework.data.jpa.domain.Specification;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 
 /**
@@ -12,16 +12,16 @@ public interface PaymentInfoSpecification {
   /**
    * Method used to verify if method create should be call.
    *
-   * @param paymentInfoRequest {@link PaymentInfoRequest}
+   * @param attributes {@link PaymentInfoRequestAttributes}
    * @return flag
    */
-  boolean shouldUse(PaymentInfoRequest paymentInfoRequest);
+  boolean shouldUse(PaymentInfoRequestAttributes attributes);
 
   /**
    * Creates Specification object.
    *
-   * @param paymentInfoRequest {@link PaymentInfoRequest}
+   * @param attributes {@link PaymentInfoRequestAttributes}
    * @return {@link Specification}
    */
-  Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequest paymentInfoRequest);
+  Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequestAttributes attributes);
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationPaymentId.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationPaymentId.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 import javax.persistence.criteria.Join;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.PaymentInfo;
 import uk.gov.caz.psr.model.info.PaymentInfo_;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
@@ -17,18 +17,18 @@ import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 public class PaymentInfoSpecificationPaymentId implements PaymentInfoSpecification {
 
   @Override
-  public boolean shouldUse(PaymentInfoRequest paymentInfoRequest) {
-    return Optional.ofNullable(paymentInfoRequest.getPaymentProviderId()).isPresent();
+  public boolean shouldUse(PaymentInfoRequestAttributes attributes) {
+    return Optional.ofNullable(attributes.getExternalPaymentId()).isPresent();
   }
 
   @Override
-  public Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequest paymentInfoRequest) {
+  public Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequestAttributes attributes) {
     return (root, criteriaQuery, criteriaBuilder) -> {
       criteriaQuery.distinct(true);
-      Join<VehicleEntrantPaymentInfo, PaymentInfo> join = QueryUtil
-          .getOrCreateJoin(root, VehicleEntrantPaymentInfo_.paymentInfo);
-      return criteriaBuilder
-          .equal(join.get(PaymentInfo_.externalId), paymentInfoRequest.getPaymentProviderId());
+      Join<VehicleEntrantPaymentInfo, PaymentInfo> join = QueryUtil.getOrCreateJoin(root,
+          VehicleEntrantPaymentInfo_.paymentInfo);
+      return criteriaBuilder.equal(join.get(PaymentInfo_.externalId),
+          attributes.getExternalPaymentId());
     };
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateFromAndTo.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateFromAndTo.java
@@ -3,7 +3,7 @@ package uk.gov.caz.psr.service.paymentinfo;
 import java.util.Optional;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 
@@ -14,18 +14,18 @@ import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 public class PaymentInfoSpecificationTravelDateFromAndTo implements PaymentInfoSpecification {
 
   @Override
-  public boolean shouldUse(PaymentInfoRequest paymentInfoRequest) {
-    return Optional.ofNullable(paymentInfoRequest.getFromDatePaidFor()).isPresent()
-        && Optional.ofNullable(paymentInfoRequest.getToDatePaidFor()).isPresent();
+  public boolean shouldUse(PaymentInfoRequestAttributes attributes) {
+    return Optional.ofNullable(attributes.getFromDatePaidFor()).isPresent()
+        && Optional.ofNullable(attributes.getToDatePaidFor()).isPresent();
   }
 
   @Override
-  public Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequest paymentInfoRequest) {
+  public Specification<VehicleEntrantPaymentInfo> create(
+      PaymentInfoRequestAttributes attributes) {
     return (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.and(
         criteriaBuilder.greaterThanOrEqualTo(root.get(VehicleEntrantPaymentInfo_.travelDate),
-            paymentInfoRequest.getFromDatePaidFor()),
-        criteriaBuilder
-            .lessThanOrEqualTo(root.get(VehicleEntrantPaymentInfo_.travelDate),
-                paymentInfoRequest.getToDatePaidFor()));
+            attributes.getFromDatePaidFor()),
+        criteriaBuilder.lessThanOrEqualTo(root.get(VehicleEntrantPaymentInfo_.travelDate),
+                attributes.getToDatePaidFor()));
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateFromOlny.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateFromOlny.java
@@ -3,7 +3,7 @@ package uk.gov.caz.psr.service.paymentinfo;
 import java.util.Optional;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 
@@ -14,15 +14,15 @@ import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 public class PaymentInfoSpecificationTravelDateFromOlny implements PaymentInfoSpecification {
 
   @Override
-  public boolean shouldUse(PaymentInfoRequest paymentInfoRequest) {
-    return Optional.ofNullable(paymentInfoRequest.getFromDatePaidFor()).isPresent()
-        && !Optional.ofNullable(paymentInfoRequest.getToDatePaidFor()).isPresent();
+  public boolean shouldUse(PaymentInfoRequestAttributes attributes) {
+    return Optional.ofNullable(attributes.getFromDatePaidFor()).isPresent()
+        && !Optional.ofNullable(attributes.getToDatePaidFor()).isPresent();
   }
 
   @Override
-  public Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequest paymentInfoRequest) {
+  public Specification<VehicleEntrantPaymentInfo> create(
+      PaymentInfoRequestAttributes attributes) {
     return (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder
-        .equal(root.get(VehicleEntrantPaymentInfo_.travelDate),
-            paymentInfoRequest.getFromDatePaidFor());
+        .equal(root.get(VehicleEntrantPaymentInfo_.travelDate), attributes.getFromDatePaidFor());
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateToOlny.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateToOlny.java
@@ -3,7 +3,7 @@ package uk.gov.caz.psr.service.paymentinfo;
 import java.util.Optional;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 
@@ -14,15 +14,16 @@ import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 public class PaymentInfoSpecificationTravelDateToOlny implements PaymentInfoSpecification {
 
   @Override
-  public boolean shouldUse(PaymentInfoRequest paymentInfoRequest) {
-    return !Optional.ofNullable(paymentInfoRequest.getFromDatePaidFor()).isPresent()
-        && Optional.ofNullable(paymentInfoRequest.getToDatePaidFor()).isPresent();
+  public boolean shouldUse(PaymentInfoRequestAttributes attributes) {
+    return !Optional.ofNullable(attributes.getFromDatePaidFor()).isPresent()
+        && Optional.ofNullable(attributes.getToDatePaidFor()).isPresent();
   }
 
   @Override
-  public Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequest paymentInfoRequest) {
+  public Specification<VehicleEntrantPaymentInfo> create(
+      PaymentInfoRequestAttributes attributes) {
     return (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder
         .equal(root.get(VehicleEntrantPaymentInfo_.travelDate),
-            paymentInfoRequest.getToDatePaidFor().minusDays(1));
+            attributes.getToDatePaidFor().minusDays(1));
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationVrn.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationVrn.java
@@ -3,7 +3,7 @@ package uk.gov.caz.psr.service.paymentinfo;
 import java.util.Optional;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 
@@ -14,14 +14,13 @@ import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
 public class PaymentInfoSpecificationVrn implements PaymentInfoSpecification {
 
   @Override
-  public boolean shouldUse(PaymentInfoRequest paymentInfoRequest) {
-    return Optional.ofNullable(paymentInfoRequest.getVrn()).isPresent();
+  public boolean shouldUse(PaymentInfoRequestAttributes attributes) {
+    return Optional.ofNullable(attributes.getVrn()).isPresent();
   }
 
   @Override
-  public Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequest paymentInfoRequest) {
+  public Specification<VehicleEntrantPaymentInfo> create(PaymentInfoRequestAttributes attributes) {
     return (root, criteriaQuery, criteriaBuilder) ->
-        criteriaBuilder.equal(root.get(VehicleEntrantPaymentInfo_.vrn),
-            paymentInfoRequest.getVrn());
+        criteriaBuilder.equal(root.get(VehicleEntrantPaymentInfo_.vrn), attributes.getVrn());
   }
 }

--- a/src/main/java/uk/gov/caz/psr/util/AttributesNormaliser.java
+++ b/src/main/java/uk/gov/caz/psr/util/AttributesNormaliser.java
@@ -1,0 +1,25 @@
+package uk.gov.caz.psr.util;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.util.StringUtils;
+
+/**
+ * A utility class that is responsible for normalising input parameters.
+ */
+@UtilityClass
+public class AttributesNormaliser {
+
+  /**
+   * Normalizes passed vrn: removes all whitespaces and makes it uppercase if not null. Returns null
+   * otherwise.
+   *
+   * @param vrn A nullable String which is to be normalised.
+   * @return A normalised VRN if not null, null otherwise.
+   */
+  public static String normalizeVrn(String vrn) {
+    if (vrn == null) {
+      return null;
+    }
+    return StringUtils.trimAllWhitespace(vrn).toUpperCase();
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/util/PaymentInfoRequestConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/PaymentInfoRequestConverter.java
@@ -1,0 +1,29 @@
+package uk.gov.caz.psr.util;
+
+import org.springframework.stereotype.Component;
+import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
+
+/**
+ * A utility class that maps instances of {@link PaymentInfoRequest} to {@link
+ * PaymentInfoRequestAttributes}.
+ */
+@Component
+public class PaymentInfoRequestConverter {
+
+  /**
+   * Converts the passed {@code request} to an instance of {@link PaymentInfoRequestAttributes}.
+   *
+   * @param request A request that is to be converted.
+   * @return An instance of {@link PaymentInfoRequestAttributes} with attributes mapped from {@code
+   *     request}.
+   */
+  public PaymentInfoRequestAttributes toPaymentInfoRequestAttributes(PaymentInfoRequest request) {
+    return PaymentInfoRequestAttributes.builder()
+        .externalPaymentId(request.getPaymentProviderId())
+        .fromDatePaidFor(request.getFromDatePaidFor())
+        .toDatePaidFor(request.getToDatePaidFor())
+        .vrn(AttributesNormaliser.normalizeVrn(request.getVrn()))
+        .build();
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
@@ -48,6 +48,7 @@ import uk.gov.caz.psr.model.PaymentStatus;
 import uk.gov.caz.psr.service.ChargeSettlementPaymentInfoService;
 import uk.gov.caz.psr.service.ChargeSettlementService;
 import uk.gov.caz.psr.service.PaymentStatusUpdateService;
+import uk.gov.caz.psr.util.PaymentInfoRequestConverter;
 import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusFactory;
 import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusUpdateDetailsFactory;
 import uk.gov.caz.psr.util.VehicleEntrantPaymentInfoConverter;
@@ -71,6 +72,8 @@ class ChargeSettlementControllerTest {
   private ChargeSettlementPaymentInfoService chargeSettlementPaymentInfoService;
   @MockBean
   private VehicleEntrantPaymentInfoConverter vehicleEntrantPaymentInfoConverter;
+  @MockBean
+  private PaymentInfoRequestConverter paymentInfoRequestConverter;
 
   private static final String ANY_VALID_VRN = "DL76MWX";
   private static final String ANY_VALID_DATE_STRING = LocalDate.now().toString();

--- a/src/test/java/uk/gov/caz/psr/service/ChargeSettlementPaymentInfoServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/ChargeSettlementPaymentInfoServiceTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.jpa.domain.Specification;
-import uk.gov.caz.psr.dto.PaymentInfoRequest;
+import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 import uk.gov.caz.psr.repository.jpa.VehicleEntrantPaymentInfoRepository;
 import uk.gov.caz.psr.service.paymentinfo.PaymentInfoSpecification;
@@ -35,7 +35,7 @@ class ChargeSettlementPaymentInfoServiceTest {
   @Test
   void shouldReturnListOfPaymentInfo() {
     // given
-    PaymentInfoRequest input = PaymentInfoRequest.builder().build();
+    PaymentInfoRequestAttributes input = PaymentInfoRequestAttributes.builder().build();
     when(vehicleEntrantPaymentInfoRepository.findAll(Mockito.any(Specification.class))).thenReturn(emptyList());
 
     //when


### PR DESCRIPTION
…and payments APIs

In ICD there is a requirement for `vrn` in _charge-settlement_ API:
> Attribute must exclude whitespace and is case insensitive.

This PR is to satisfy it.