### PR TITLE
CAZ-1627 Filter out unsuccessful payments from payment-info endpoint

### DIFF
--- a/src/it/java/uk/gov/caz/psr/ChargeSettlementPaymentInfoTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/ChargeSettlementPaymentInfoTestIT.java
@@ -63,6 +63,7 @@ class ChargeSettlementPaymentInfoTestIT {
             .then()
             .headerContainsCorrelationId()
             .reponseHasOkStatus()
+            .doesNotContainNotPaidEntries()
             .containsExactlyLineItemsWithTravelDates(expectedPaidEntrantDate.toString())
             .totalLineItemsCountIsEqualTo(2);
       }
@@ -72,7 +73,7 @@ class ChargeSettlementPaymentInfoTestIT {
     class AndThereAreNoMatchingLineItems {
 
       @ParameterizedTest
-      @ValueSource(strings = {"2019-11-01", "2019-11-09"})
+      @ValueSource(strings = {"2019-11-01", "2019-11-10"})
       public void shouldReturnEmptyArray(String toDatePaidForAsString) {
         LocalDate toDatePaidFor = LocalDate.parse(toDatePaidForAsString);
 
@@ -102,6 +103,7 @@ class ChargeSettlementPaymentInfoTestIT {
             .then()
             .headerContainsCorrelationId()
             .reponseHasOkStatus()
+            .doesNotContainNotPaidEntries()
             .containsExactlyLineItemsWithTravelDates(fromDatePaidForAsString)
             .totalLineItemsCountIsEqualTo(2);
       }
@@ -111,7 +113,7 @@ class ChargeSettlementPaymentInfoTestIT {
     class AndThereAreNoMatchingLineItems {
 
       @ParameterizedTest
-      @ValueSource(strings = {"2019-10-31", "2019-11-08", "2019-11-15"})
+      @ValueSource(strings = {"2019-10-31", "2019-11-09", "2019-11-15"})
       public void shouldReturnEmptyArray(String fromDatePaidForAsString) {
         LocalDate fromDatePaidFor = LocalDate.parse(fromDatePaidForAsString);
 
@@ -159,6 +161,7 @@ class ChargeSettlementPaymentInfoTestIT {
             .then()
             .headerContainsCorrelationId()
             .reponseHasOkStatus()
+            .doesNotContainNotPaidEntries()
             .totalLineItemsCountIsEqualTo(expectedLineItemsCount);
       }
     }
@@ -254,6 +257,7 @@ class ChargeSettlementPaymentInfoTestIT {
             .reponseHasOkStatus()
             .containsExactlyVrns(vrn)
             .containsExactlyLineItemsWithTravelDates("2019-11-01", "2019-11-02")
+            .doesNotContainNotPaidEntries()
             .totalLineItemsCountIsEqualTo(2);
       }
 
@@ -275,6 +279,7 @@ class ChargeSettlementPaymentInfoTestIT {
                 .then()
                 .headerContainsCorrelationId()
                 .reponseHasOkStatus()
+                .doesNotContainNotPaidEntries()
                 .containsExactlyVrns(vrn)
                 .containsExactlyLineItemsWithTravelDates(expectedPaidEntrantDate.toString())
                 .totalLineItemsCountIsEqualTo(1);
@@ -285,7 +290,7 @@ class ChargeSettlementPaymentInfoTestIT {
         class AndThereAreNoMatchingLineItems {
 
           @ParameterizedTest
-          @ValueSource(strings = {"2019-11-01", "2019-11-09"})
+          @ValueSource(strings = {"2019-11-01", "2019-11-10"})
           public void shouldReturnEmptyArray(String toDatePaidForAsString) {
             String vrn = "ND84VSX";
             LocalDate toDatePaidFor = LocalDate.parse(toDatePaidForAsString);
@@ -316,6 +321,7 @@ class ChargeSettlementPaymentInfoTestIT {
                 .then()
                 .headerContainsCorrelationId()
                 .reponseHasOkStatus()
+                .doesNotContainNotPaidEntries()
                 .containsExactlyVrns(vrn)
                 .containsExactlyLineItemsWithTravelDates(fromDatePaidForAsString)
                 .totalLineItemsCountIsEqualTo(1);
@@ -326,7 +332,7 @@ class ChargeSettlementPaymentInfoTestIT {
         class AndThereAreNoMatchingLineItems {
 
           @ParameterizedTest
-          @ValueSource(strings = {"2019-10-31", "2019-11-08"})
+          @ValueSource(strings = {"2019-10-31", "2019-11-09"})
           public void shouldReturnEmptyArray(String fromDatePaidForAsString) {
             String vrn = "ND84VSX";
 
@@ -359,6 +365,7 @@ class ChargeSettlementPaymentInfoTestIT {
                 .then()
                 .headerContainsCorrelationId()
                 .reponseHasOkStatus()
+                .doesNotContainNotPaidEntries()
                 .totalLineItemsCountIsEqualTo(expectedLineItemsCount);
           }
         }
@@ -528,6 +535,7 @@ class ChargeSettlementPaymentInfoTestIT {
             .then()
             .headerContainsCorrelationId()
             .reponseHasOkStatus()
+            .doesNotContainNotPaidEntries()
             .containsOnePaymentWithProviderIdEqualTo(paymentProviderId)
             .containsExactlyVrns("AB11CDE")
             .containsExactlyLineItemsWithTravelDates("2019-11-01", "2019-11-02")
@@ -550,6 +558,7 @@ class ChargeSettlementPaymentInfoTestIT {
                 .then()
                 .headerContainsCorrelationId()
                 .reponseHasOkStatus()
+                .doesNotContainNotPaidEntries()
                 .containsExactlyVrns(matchingVrn)
                 .containsOnePaymentWithProviderIdEqualTo(paymentProviderId)
                 .containsExactlyLineItemsWithTravelDates("2019-11-01", "2019-11-02", "2019-11-03",
@@ -572,7 +581,9 @@ class ChargeSettlementPaymentInfoTestIT {
                   .withParam("vrn", matchingVrn)
                   .withParam("paymentProviderId", paymentProviderId)
                   .then()
+                  .reponseHasOkStatus()
                   .headerContainsCorrelationId()
+                  .doesNotContainNotPaidEntries()
                   .containsOnePaymentWithProviderIdEqualTo(paymentProviderId)
                   .containsExactlyVrns(matchingVrn)
                   .containsExactlyLineItemsWithTravelDates("2019-11-03", "2019-11-04", "2019-11-05");
@@ -593,6 +604,8 @@ class ChargeSettlementPaymentInfoTestIT {
                   .withParam("paymentProviderId", paymentProviderId)
                   .then()
                   .headerContainsCorrelationId()
+                  .reponseHasOkStatus()
+                  .doesNotContainNotPaidEntries()
                   .containsOnePaymentWithProviderIdEqualTo(paymentProviderId)
                   .containsExactlyVrns(matchingVrn)
                   .containsExactlyLineItemsWithTravelDates("2019-11-03");
@@ -613,6 +626,8 @@ class ChargeSettlementPaymentInfoTestIT {
                   .withParam("paymentProviderId", paymentProviderId)
                   .then()
                   .headerContainsCorrelationId()
+                  .reponseHasOkStatus()
+                  .doesNotContainNotPaidEntries()
                   .containsOnePaymentWithProviderIdEqualTo(paymentProviderId)
                   .containsExactlyVrns(matchingVrn)
                   .containsExactlyLineItemsWithTravelDates("2019-11-02");
@@ -768,6 +783,12 @@ class ChargeSettlementPaymentInfoTestIT {
           .header(Headers.X_API_KEY, API_KEY_FOR_EXISTING_RECORDS)
           .header(Headers.TIMESTAMP, LocalDateTime.now().toString());
     }
+
+    public PaymentInfoAssertion doesNotContainNotPaidEntries() {
+      validatableResponse.body("results.payments.lineItems.findAll { it.paymentStatus == "
+              + "'notPaid' }.paymentStatus.flatten().toSet().size()", equalTo(0));
+      return this;
+    }
   }
 
   @BeforeEach
@@ -799,8 +820,8 @@ class ChargeSettlementPaymentInfoTestIT {
     return Stream.of(
         Arguments.of("2019-05-01", "2019-05-01"),
         Arguments.of("1998-05-01", "2003-01-02"),
-        Arguments.of("2019-11-08", "2019-11-08"),
-        Arguments.of("2019-11-08", "2019-11-09"),
+        Arguments.of("2019-11-09", "2019-11-09"),
+        Arguments.of("2019-11-09", "2019-11-10"),
         Arguments.of("2019-10-30", "2019-10-31")
     );
   }
@@ -813,9 +834,9 @@ class ChargeSettlementPaymentInfoTestIT {
         Arguments.of("1993-04-18", "2019-11-02", 2),
         Arguments.of("2019-11-02", "2019-11-06", 5),
         Arguments.of("2019-11-03", "2019-11-07", 5),
-        Arguments.of("2019-11-07", "2019-11-08", 1),
-        Arguments.of("2019-11-07", "2025-02-19", 1),
-        Arguments.of("2019-11-07", "2031-09-22", 1)
+        Arguments.of("2019-11-07", "2019-11-08", 2),
+        Arguments.of("2019-11-07", "2025-02-19", 2),
+        Arguments.of("2019-11-07", "2031-09-22", 2)
     );
   }
 
@@ -824,8 +845,8 @@ class ChargeSettlementPaymentInfoTestIT {
     return Stream.of(
         Arguments.of("2019-05-01", "2019-05-01"),
         Arguments.of("1998-05-01", "2003-01-02"),
-        Arguments.of("2019-11-08", "2019-11-08"),
-        Arguments.of("2019-11-08", "2019-11-09"),
+        Arguments.of("2019-11-09", "2019-11-09"),
+        Arguments.of("2019-11-09", "2019-11-10"),
         Arguments.of("2019-10-30", "2019-10-31")
     );
   }
@@ -837,9 +858,9 @@ class ChargeSettlementPaymentInfoTestIT {
         Arguments.of("1993-04-18", "2019-11-02", 4),
         Arguments.of("2019-11-02", "2019-11-06", 6),
         Arguments.of("2019-11-03", "2019-11-07", 5),
-        Arguments.of("2019-11-07", "2019-11-08", 1),
-        Arguments.of("2019-11-07", "2025-02-19", 1),
-        Arguments.of("2019-11-07", "2031-09-22", 1)
+        Arguments.of("2019-11-07", "2019-11-08", 2),
+        Arguments.of("2019-11-07", "2025-02-19", 2),
+        Arguments.of("2019-11-07", "2031-09-22", 2)
     );
   }
 

--- a/src/it/resources/data/sql/charge-settlement/payment-info/test-data.sql
+++ b/src/it/resources/data/sql/charge-settlement/payment-info/test-data.sql
@@ -10,7 +10,7 @@ values
 ('d22c4d6c-0f8d-11ea-bbdd-7ff4b1cc8ff1', 'd80deb4e-0f8a-11ea-8dc9-93fa5be4476e', 'ND84VSX', '53e03a28-0627-11ea-9511-ffaaee87e375', '2019-11-04', 88, 'PAID'),
 ('d572fea8-0f8d-11ea-bbdd-2b420f74f6f3', 'd80deb4e-0f8a-11ea-8dc9-93fa5be4476e', 'ND84VSX', '53e03a28-0627-11ea-9511-ffaaee87e375', '2019-11-05', 88, 'PAID');
 
--- failed payment for 'ND84VSX' vrn
+-- failed payment for 'ND84VSX' vrn for '2019-11-06' and '2019-11-07' travel dates
 insert into payment(payment_id, payment_provider_id, payment_method, payment_provider_status, total_paid, payment_submitted_timestamp)
 values ('2ed40346-0f90-11ea-bbdd-3f18854148eb', 'ext-payment-id-2', 'CREDIT_DEBIT_CARD', 'FAILED', 100, '2019-11-23T20:38:08.272Z');
 
@@ -19,6 +19,15 @@ values
 ('62320a6c-0f90-11ea-bbdd-b3fa7794610e', '2ed40346-0f90-11ea-bbdd-3f18854148eb', 'ND84VSX', '53e03a28-0627-11ea-9511-ffaaee87e375', '2019-11-06', 50, 'NOT_PAID'),
 ('65821f90-0f90-11ea-bbdd-9bba0c562c82', '2ed40346-0f90-11ea-bbdd-3f18854148eb', 'ND84VSX', '53e03a28-0627-11ea-9511-ffaaee87e375', '2019-11-07', 50, 'NOT_PAID');
 
+-- successful payment with different statuses for 'ND84VSX' and '2019-11-06', '2019-11-07' and '2019-11-08' travel dates
+insert into payment(payment_id, payment_provider_id, payment_method, payment_provider_status, total_paid, payment_submitted_timestamp)
+values ('de551408-1cca-11ea-8052-efd996bcf49c', 'ext-payment-id-4', 'CREDIT_DEBIT_CARD', 'FAILED', 540, '2019-11-22T20:38:08.272Z');
+
+insert into vehicle_entrant_payment (vehicle_entrant_payment_id, payment_id, vrn, caz_id, travel_date, charge_paid, payment_status)
+values
+('2cba820e-1ccb-11ea-8052-174f5b2d3113', 'de551408-1cca-11ea-8052-efd996bcf49c', 'ND84VSX', '53e03a28-0627-11ea-9511-ffaaee87e375', '2019-11-06', 180, 'PAID'),
+('2f4652c8-1ccb-11ea-8052-37ec9c9665b9', 'de551408-1cca-11ea-8052-efd996bcf49c', 'ND84VSX', '53e03a28-0627-11ea-9511-ffaaee87e375', '2019-11-07', 180, 'REFUNDED'),
+('5a4fdee8-1cd1-11ea-8bae-6f5a85323c9b', 'de551408-1cca-11ea-8052-efd996bcf49c', 'ND84VSX', '53e03a28-0627-11ea-9511-ffaaee87e375', '2019-11-08', 180, 'CHARGEBACK');
 
 -- successful payment for 'AB11CDE' vrn
 insert into payment(payment_id, payment_provider_id, payment_method, payment_provider_status, total_paid, payment_submitted_timestamp, payment_authorised_timestamp)

--- a/src/main/java/uk/gov/caz/psr/service/ChargeSettlementPaymentInfoService.java
+++ b/src/main/java/uk/gov/caz/psr/service/ChargeSettlementPaymentInfoService.java
@@ -10,6 +10,7 @@ import uk.gov.caz.psr.model.info.PaymentInfo;
 import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
 import uk.gov.caz.psr.repository.jpa.VehicleEntrantPaymentInfoRepository;
 import uk.gov.caz.psr.service.paymentinfo.CazIdSpecification;
+import uk.gov.caz.psr.service.paymentinfo.OmitNotPaidPaymentInfoSpecification;
 import uk.gov.caz.psr.service.paymentinfo.PaymentInfoSpecification;
 
 /**
@@ -35,8 +36,16 @@ public class ChargeSettlementPaymentInfoService {
     Specification<VehicleEntrantPaymentInfo> specification = specifications.stream()
         .filter(paymentInfoSpecification -> paymentInfoSpecification.shouldUse(attributes))
         .map(paymentInfoSpecification -> paymentInfoSpecification.create(attributes))
-        .reduce(CazIdSpecification.forCaz(cazId), Specification::and);
+        .reduce(initialSpecification(cazId), Specification::and);
 
     return vehicleEntrantPaymentInfoRepository.findAll(specification);
+  }
+
+  /**
+   * Returns the initial specification that selects entries for a given {@code cazId} and
+   * does not include payments with {@code notPaid} status.
+   */
+  private Specification<VehicleEntrantPaymentInfo> initialSpecification(UUID cazId) {
+    return CazIdSpecification.forCaz(cazId).and(new OmitNotPaidPaymentInfoSpecification());
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/OmitNotPaidPaymentInfoSpecification.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/OmitNotPaidPaymentInfoSpecification.java
@@ -1,0 +1,24 @@
+package uk.gov.caz.psr.service.paymentinfo;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.caz.psr.model.InternalPaymentStatus;
+import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo;
+import uk.gov.caz.psr.model.info.VehicleEntrantPaymentInfo_;
+
+/**
+ * A specification that does not include vehicle entrant payments with {@code notPaid} status.
+ */
+public class OmitNotPaidPaymentInfoSpecification
+    implements Specification<VehicleEntrantPaymentInfo> {
+
+  @Override
+  public Predicate toPredicate(Root<VehicleEntrantPaymentInfo> root, CriteriaQuery<?> criteriaQuery,
+      CriteriaBuilder criteriaBuilder) {
+    return criteriaBuilder.notEqual(root.get(VehicleEntrantPaymentInfo_.paymentStatus),
+        InternalPaymentStatus.NOT_PAID);
+  }
+}


### PR DESCRIPTION
* add a new specification that does not include not paid payments
* modify integration tests