### PR TITLE
[CAZ-1436] Change Payment Description in GOV.UK PAY

### DIFF
--- a/src/it/resources/data/external/create-payment-response.json
+++ b/src/it/resources/data/external/create-payment-response.json
@@ -1,6 +1,6 @@
 {
   "amount": 4200,
-  "description": "Payment for #2827167e-fa0e-11e9-8c20-5705c5450e03",
+  "description": "Driving in a Clean Air Zone charge",
   "reference": "2827167e-fa0e-11e9-8c20-5705c5450e03",
   "language": "en",
   "state": {

--- a/src/it/resources/data/external/dangling/cancelled-payment.json
+++ b/src/it/resources/data/external/dangling/cancelled-payment.json
@@ -1,6 +1,6 @@
 {
   "amount": 1000,
-  "description": "Payment for #33afefda-046c-11ea-b55b-5b826ca628bc",
+  "description": "Driving in a Clean Air Zone charge",
   "reference": "33afefda-046c-11ea-b55b-5b826ca628bc",
   "language": "en",
   "state": {

--- a/src/it/resources/data/external/dangling/expired-payment.json
+++ b/src/it/resources/data/external/dangling/expired-payment.json
@@ -1,6 +1,6 @@
 {
   "amount": 1000,
-  "description": "Payment for #a5f0687c-046c-11ea-b55b-677d1f5017cf",
+  "description": "Driving in a Clean Air Zone charge",
   "reference": "a5f0687c-046c-11ea-b55b-677d1f5017cf",
   "language": "en",
   "state": {

--- a/src/it/resources/data/external/dangling/success-payment.json
+++ b/src/it/resources/data/external/dangling/success-payment.json
@@ -1,6 +1,6 @@
 {
   "amount": 3200,
-  "description": "Payment for #343ef20e-0541-11ea-aff3-6bd124c3a586",
+  "description": "Driving in a Clean Air Zone charge",
   "reference": "343ef20e-0541-11ea-aff3-6bd124c3a586",
   "language": "en",
   "email": "success-payment@informed.com",

--- a/src/it/resources/data/external/get-payment-response.json
+++ b/src/it/resources/data/external/get-payment-response.json
@@ -1,6 +1,6 @@
 {
   "amount": 4200,
-  "description": "Payment for #2827167e-fa0e-11e9-8c20-5705c5450e03",
+  "description": "Driving in a Clean Air Zone charge",
   "reference": "2827167e-fa0e-11e9-8c20-5705c5450e03",
   "language": "en",
   "email": "radoslaw.morytko@informed.com",

--- a/src/main/java/uk/gov/caz/psr/repository/ExternalPaymentsRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/ExternalPaymentsRepository.java
@@ -198,7 +198,8 @@ public class ExternalPaymentsRepository {
    */
   private CreateCardPaymentRequest buildCreateBody(Payment payment, String returnUrl) {
     return CreateCardPaymentRequest.builder().amount(payment.getTotalPaid())
-        .description("Payment for #" + payment.getId()).reference(payment.getId().toString())
+        .description("Driving in a Clean Air Zone charge")
+        .reference(payment.getId().toString())
         .returnUrl(returnUrl).build();
   }
 


### PR DESCRIPTION
Jira Card: https://eaflood.atlassian.net/browse/CAZ-1436

Updated the text which we send as a description to GOV.UK Pay during payment creation. 

Decided to do it as a simple change of text because we will have a separate card for it during fleets implementation to display a more advanced message. For now Payment Service don't support payments for multiple vrns in single request. 