### PR TITLE
[do not merge] Generate central reference number and return to front end

### DIFF
--- a/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
@@ -24,6 +24,7 @@ import uk.gov.caz.psr.dto.Headers;
 import uk.gov.caz.psr.dto.PaymentStatusResponse;
 import uk.gov.caz.psr.model.InternalPaymentStatus;
 import uk.gov.caz.psr.model.PaymentStatus;
+import uk.gov.caz.psr.repository.PaymentRepository;
 import uk.gov.caz.psr.repository.PaymentStatusRepository;
 import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusFactory;
 
@@ -46,6 +47,7 @@ public class GetChargeSettlementPaymentStatusTestIT {
 
   private static final String VALID_EXTERNAL_ID = "54321test";
   private static final String VALID_CASE_REFERENCE = "case-reference123";
+  private static final Long VALID_PAYMENT_REFERENCE = (long) 3001;
   private static final String PAYMENT_STATUS_GET_PATH = ChargeSettlementController.BASE_PATH +
       ChargeSettlementController.PAYMENT_STATUS_PATH;
 
@@ -55,6 +57,8 @@ public class GetChargeSettlementPaymentStatusTestIT {
   private ObjectMapper objectMapper;
   @Autowired
   private PaymentStatusRepository paymentStatusRepository;
+  @Autowired
+  private PaymentRepository paymentsRepository;
 
   @Test
   public void shouldReturn200WithNotPaidStatusWhenDoesNotExistInDatabase() throws Exception {
@@ -109,7 +113,7 @@ public class GetChargeSettlementPaymentStatusTestIT {
         .param("dateOfCazEntry", VALID_DATE_WITH_DIFFERENT_STATUSES))
         .andExpect(status().isOk())
         .andExpect(content().json(
-            getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE, VALID_EXTERNAL_ID)));
+            getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE, VALID_EXTERNAL_ID, VALID_PAYMENT_REFERENCE)));
   }
 
   @ParameterizedTest
@@ -131,7 +135,7 @@ public class GetChargeSettlementPaymentStatusTestIT {
         .andExpect(status().isOk())
         .andExpect(content().json(
             getResponseWith(InternalPaymentStatus.REFUNDED, VALID_CASE_REFERENCE,
-                VALID_EXTERNAL_ID)));
+                VALID_EXTERNAL_ID, VALID_PAYMENT_REFERENCE)));
   }
 
   private String getNotPaidResponse() {
@@ -142,12 +146,13 @@ public class GetChargeSettlementPaymentStatusTestIT {
   }
 
   private String getResponseWith(InternalPaymentStatus internalPaymentStatus, String caseReference,
-      String externalId) {
+      String externalId, Long paymentReference) {
     PaymentStatusResponse paymentStatusResponse = PaymentStatusResponse
         .from(PaymentStatusFactory.with(
             internalPaymentStatus,
             caseReference,
-            externalId
+            externalId,
+            paymentReference
         ));
 
     return toJsonString(paymentStatusResponse);

--- a/src/it/java/uk/gov/caz/psr/ReconcilePaymentStatusTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/ReconcilePaymentStatusTestIT.java
@@ -1,6 +1,7 @@
 package uk.gov.caz.psr;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import java.util.UUID;
@@ -27,9 +28,10 @@ import uk.gov.caz.psr.util.TestObjectFactory;
     executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 @IntegrationTest
 @AutoConfigureMockMvc
-public class GetAndUpdatePaymentStatusTestIT {
+public class ReconcilePaymentStatusTestIT {
 
   private static final String URL_TEMPLATE = PaymentsController.BASE_PATH + "/{id}";
+  private static final String BODY = "{\"cleanAirZoneName\": \"Leeds\"}";
   @Autowired
   private MockMvc mockMvc;
 
@@ -41,7 +43,9 @@ public class GetAndUpdatePaymentStatusTestIT {
   public void shouldReturn400StatusWhenIdHasInvalidFormat(String id) throws Exception {
     String correlationId = "31f69f26-fb99-11e9-8483-9fcf0b2b434f";
     mockMvc
-        .perform(get(URL_TEMPLATE, id).header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+        .perform(put(URL_TEMPLATE, id).content(BODY)
+            .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+            .header("content-type", MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, correlationId))
         .andExpect(status().isBadRequest());
@@ -53,8 +57,9 @@ public class GetAndUpdatePaymentStatusTestIT {
 
     String correlationId = "542de1b5-4aab-45eb-bccc-6ec91f1d6d51";
     mockMvc
-        .perform(get(URL_TEMPLATE, notExistingId)
+        .perform(put(URL_TEMPLATE, notExistingId).content(BODY)
             .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+            .header("content-type", MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, correlationId))
         .andExpect(status().isNotFound());
@@ -67,7 +72,9 @@ public class GetAndUpdatePaymentStatusTestIT {
     String correlationId = "939898b0-fb9e-11e9-8483-cb50ccd05275";
     mockMvc
         .perform(
-            get(URL_TEMPLATE, paymentId).header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+            put(URL_TEMPLATE, paymentId).content(BODY)
+            .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
+            .header("content-type", MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, correlationId))
         .andExpect(status().isNotFound());

--- a/src/it/java/uk/gov/caz/psr/SuccessPaymentsJourneyTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/SuccessPaymentsJourneyTestIT.java
@@ -38,9 +38,10 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import uk.gov.caz.correlationid.Constants;
 import uk.gov.caz.psr.annotation.FullyRunningServerIntegrationTest;
-import uk.gov.caz.psr.dto.GetAndUpdatePaymentStatusResponse;
+import uk.gov.caz.psr.dto.ReconcilePaymentResponse;
 import uk.gov.caz.psr.dto.InitiatePaymentRequest;
 import uk.gov.caz.psr.dto.InitiatePaymentResponse;
+import uk.gov.caz.psr.dto.ReconcilePaymentRequest;
 import uk.gov.caz.psr.model.ExternalPaymentStatus;
 import uk.gov.caz.psr.model.InternalPaymentStatus;
 import uk.gov.caz.psr.model.PaymentMethod;
@@ -153,7 +154,7 @@ public class SuccessPaymentsJourneyTestIT {
 
     private InitiatePaymentRequest initiatePaymentRequest;
     private InitiatePaymentResponse initPaymentResponse;
-    private GetAndUpdatePaymentStatusResponse getAndUpdatePaymentResponse;
+    private ReconcilePaymentResponse getAndUpdatePaymentResponse;
 
     public PaymentJourneyAssertion initiatePaymentRequest(InitiatePaymentRequest request) {
       this.initiatePaymentRequest = request;
@@ -206,13 +207,16 @@ public class SuccessPaymentsJourneyTestIT {
 
     public PaymentJourneyAssertion whenRequestedToGetAndUpdateStatus() {
       String correlationId = "e879d028-2882-4f0b-b3b3-06d7fbcd8537";
+      ReconcilePaymentRequest request = ReconcilePaymentRequest.builder()
+          .cleanAirZoneName("Leeds").build();
       this.getAndUpdatePaymentResponse = RestAssured.given()
           .accept(MediaType.APPLICATION_JSON.toString())
+          .body(request)
           .contentType(MediaType.APPLICATION_JSON.toString())
           .header(Constants.X_CORRELATION_ID_HEADER, correlationId).when()
-          .get(initPaymentResponse.getPaymentId().toString()).then()
+          .put(initPaymentResponse.getPaymentId().toString()).then()
           .header(Constants.X_CORRELATION_ID_HEADER, correlationId)
-          .statusCode(HttpStatus.OK.value()).extract().as(GetAndUpdatePaymentStatusResponse.class);
+          .statusCode(HttpStatus.OK.value()).extract().as(ReconcilePaymentResponse.class);
       return this;
     }
 

--- a/src/it/resources/data/sql/add-payments-for-payment-status.sql
+++ b/src/it/resources/data/sql/add-payments-for-payment-status.sql
@@ -1,8 +1,8 @@
 INSERT INTO payment(
-	payment_id, payment_method, payment_provider_id, total_paid, payment_submitted_timestamp, payment_authorised_timestamp)
+	payment_id, payment_method, payment_provider_id, total_paid, payment_submitted_timestamp, payment_authorised_timestamp, central_reference_number)
 	VALUES
-	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', '12345test', 100, now(), now()),
-	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', '54321test', 200, now(), now());
+	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', '12345test', 100, now(), now(), 3000),
+	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', '54321test', 200, now(), now(), 3001);
 
 INSERT INTO vehicle_entrant_payment(
 	vehicle_entrant_payment_id, vehicle_entrant_id, payment_id, vrn, caz_id, travel_date, charge_paid, payment_status, case_reference)

--- a/src/main/java/uk/gov/caz/psr/controller/PaymentsController.java
+++ b/src/main/java/uk/gov/caz/psr/controller/PaymentsController.java
@@ -7,12 +7,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.caz.psr.dto.GetAndUpdatePaymentStatusResponse;
 import uk.gov.caz.psr.dto.InitiatePaymentRequest;
 import uk.gov.caz.psr.dto.InitiatePaymentResponse;
+import uk.gov.caz.psr.dto.ReconcilePaymentRequest;
+import uk.gov.caz.psr.dto.ReconcilePaymentResponse;
 import uk.gov.caz.psr.model.Payment;
-import uk.gov.caz.psr.service.GetAndUpdatePaymentsService;
 import uk.gov.caz.psr.service.InitiatePaymentService;
+import uk.gov.caz.psr.service.ReconcilePaymentStatusService;
 
 @RestController
 @AllArgsConstructor
@@ -22,7 +23,7 @@ public class PaymentsController implements PaymentsControllerApiSpec {
   public static final String BASE_PATH = "/v1/payments";
 
   private final InitiatePaymentService initiatePaymentService;
-  private final GetAndUpdatePaymentsService getAndUpdatePaymentsService;
+  private final ReconcilePaymentStatusService reconcilePaymentStatusService;
 
   @Override
   public ResponseEntity<InitiatePaymentResponse> initiatePayment(InitiatePaymentRequest request) {
@@ -32,10 +33,11 @@ public class PaymentsController implements PaymentsControllerApiSpec {
   }
 
   @Override
-  public ResponseEntity<GetAndUpdatePaymentStatusResponse> getExternalPaymentAndUpdateStatus(
-      UUID id) {
-    Optional<Payment> payment = getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(id);
-    return payment.map(GetAndUpdatePaymentStatusResponse::from)
+  public ResponseEntity<ReconcilePaymentResponse> reconcilePaymentStatus(
+      UUID id, ReconcilePaymentRequest request) {
+    Optional<Payment> payment = reconcilePaymentStatusService
+        .reconcilePaymentStatus(id, request.getCleanAirZoneName());
+    return payment.map(ReconcilePaymentResponse::from)
         .map(ResponseEntity::ok)
         .orElseGet(() -> ResponseEntity.notFound().build());
   }

--- a/src/main/java/uk/gov/caz/psr/controller/PaymentsControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/PaymentsControllerApiSpec.java
@@ -12,16 +12,17 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
-import uk.gov.caz.psr.dto.GetAndUpdatePaymentStatusResponse;
 import uk.gov.caz.psr.dto.InitiatePaymentRequest;
 import uk.gov.caz.psr.dto.InitiatePaymentResponse;
 import uk.gov.caz.psr.dto.PaymentStatusResponse;
+import uk.gov.caz.psr.dto.ReconcilePaymentRequest;
+import uk.gov.caz.psr.dto.ReconcilePaymentResponse;
 
 @RequestMapping(
     value = PaymentsController.BASE_PATH,
@@ -54,7 +55,8 @@ public interface PaymentsControllerApiSpec {
   ResponseEntity<InitiatePaymentResponse> initiatePayment(
       @Valid @RequestBody InitiatePaymentRequest request);
 
-  @GetMapping("/{id}")
-  ResponseEntity<GetAndUpdatePaymentStatusResponse> getExternalPaymentAndUpdateStatus(
-      @PathVariable UUID id);
+  @PutMapping("/{id}")
+  @ResponseStatus(HttpStatus.OK)
+  ResponseEntity<ReconcilePaymentResponse> reconcilePaymentStatus(
+      @PathVariable UUID id, @RequestBody ReconcilePaymentRequest request);
 }

--- a/src/main/java/uk/gov/caz/psr/dto/GetAndUpdatePaymentStatusResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/GetAndUpdatePaymentStatusResponse.java
@@ -13,6 +13,12 @@ import uk.gov.caz.psr.model.Payment;
 public class GetAndUpdatePaymentStatusResponse {
   @NonNull
   UUID paymentId;
+  
+  @NonNull
+  Long referenceNumber;
+  
+  @NonNull
+  String externalPaymentId;
 
   @NonNull
   SuccessFailurePaymentStatus status;
@@ -23,7 +29,8 @@ public class GetAndUpdatePaymentStatusResponse {
    * Creates an instance of this class based on the passed {@link Payment} instance.
    */
   public static GetAndUpdatePaymentStatusResponse from(Payment payment) {
-    return new GetAndUpdatePaymentStatusResponse(payment.getId(),
+    return new GetAndUpdatePaymentStatusResponse(payment.getId(), payment.getReferenceNumber(),
+        payment.getExternalId(), 
         SuccessFailurePaymentStatus.from(payment.getExternalPaymentStatus()),
         payment.getEmailAddress());
   }

--- a/src/main/java/uk/gov/caz/psr/dto/PaymentInfoResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentInfoResponse.java
@@ -28,6 +28,9 @@ public class PaymentInfoResponse {
   @Value
   @Builder
   public static class SinglePaymentInfo {
+    @ApiModelProperty(value = "${swagger.model.descriptions.payment-info.caz-payment-reference}")
+    Long cazPaymentReference;
+    
     @ApiModelProperty(value = "${swagger.model.descriptions.payment-info.payment-provider-id}")
     String paymentProviderId;
 

--- a/src/main/java/uk/gov/caz/psr/dto/PaymentStatusResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentStatusResponse.java
@@ -14,6 +14,10 @@ public class PaymentStatusResponse {
   @NotNull
   ChargeSettlementPaymentStatus paymentStatus;
 
+  @ApiModelProperty(value = "${swagger.model.descriptions.payment-status.caz-payment-reference}")
+  @NotNull
+  Long cazPaymentReference;
+
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status.payment-provider-id}")
   @Max(255)
   String paymentProviderId;
@@ -30,6 +34,7 @@ public class PaymentStatusResponse {
   public static PaymentStatusResponse from(PaymentStatus paymentStatus) {
     return PaymentStatusResponse.builder()
         .paymentStatus(ChargeSettlementPaymentStatus.from(paymentStatus.getStatus()))
+        .cazPaymentReference(paymentStatus.getPaymentReference())
         .paymentProviderId(paymentStatus.getExternalId())
         .caseReference(paymentStatus.getCaseReference())
         .build();

--- a/src/main/java/uk/gov/caz/psr/dto/ReconcilePaymentRequest.java
+++ b/src/main/java/uk/gov/caz/psr/dto/ReconcilePaymentRequest.java
@@ -1,0 +1,18 @@
+package uk.gov.caz.psr.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class ReconcilePaymentRequest {
+
+  @ApiModelProperty(value = "${swagger.model.descriptions.payments-get-status.clean-air-zone-name}")
+  @NotBlank
+  @Size(min = 1, max = 58)
+  String cleanAirZoneName;
+
+}

--- a/src/main/java/uk/gov/caz/psr/dto/ReconcilePaymentResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/ReconcilePaymentResponse.java
@@ -10,7 +10,7 @@ import uk.gov.caz.psr.model.Payment;
  * update the status.
  */
 @Value
-public class GetAndUpdatePaymentStatusResponse {
+public class ReconcilePaymentResponse {
   @NonNull
   UUID paymentId;
   
@@ -28,8 +28,8 @@ public class GetAndUpdatePaymentStatusResponse {
   /**
    * Creates an instance of this class based on the passed {@link Payment} instance.
    */
-  public static GetAndUpdatePaymentStatusResponse from(Payment payment) {
-    return new GetAndUpdatePaymentStatusResponse(payment.getId(), payment.getReferenceNumber(),
+  public static ReconcilePaymentResponse from(Payment payment) {
+    return new ReconcilePaymentResponse(payment.getId(), payment.getReferenceNumber(),
         payment.getExternalId(), 
         SuccessFailurePaymentStatus.from(payment.getExternalPaymentStatus()),
         payment.getEmailAddress());

--- a/src/main/java/uk/gov/caz/psr/model/Payment.java
+++ b/src/main/java/uk/gov/caz/psr/model/Payment.java
@@ -24,6 +24,11 @@ public class Payment {
    * The unique payment identifier from GOV UK Pay service.
    */
   String externalId;
+  
+  /**
+   * The central reference number of the payment.
+   */
+  Long referenceNumber;
 
   /**
    * The method of payment.
@@ -92,8 +97,9 @@ public class Payment {
           "authorisedTimestamp is null and external payment status is not 'SUCCESS' or "
               + "authorisedTimestamp is not null and external payment status is 'SUCCESS'");
 
-      return new Payment(id, externalId, paymentMethod, totalPaid, vehicleEntrantPayments,
-          externalPaymentStatus, submittedTimestamp, authorisedTimestamp, nextUrl, emailAddress);
+      return new Payment(id, externalId, referenceNumber, paymentMethod, totalPaid, 
+          vehicleEntrantPayments,  externalPaymentStatus, submittedTimestamp, authorisedTimestamp, 
+          nextUrl, emailAddress);
     }
 
     private boolean externalStatusMatchesExternalPaymentId() {

--- a/src/main/java/uk/gov/caz/psr/model/Payment.java
+++ b/src/main/java/uk/gov/caz/psr/model/Payment.java
@@ -77,6 +77,12 @@ public class Payment {
    * payment. A transient field, not saved in the database.
    */
   String emailAddress;
+  
+  /**
+   * The name of the Clean Air Zone the payment is being made to. A transient field, not saved
+   * in the database.
+   */
+  String cleanAirZoneName;
 
   /**
    * An overridden lombok's builder.
@@ -99,7 +105,7 @@ public class Payment {
 
       return new Payment(id, externalId, referenceNumber, paymentMethod, totalPaid, 
           vehicleEntrantPayments,  externalPaymentStatus, submittedTimestamp, authorisedTimestamp, 
-          nextUrl, emailAddress);
+          nextUrl, emailAddress, cleanAirZoneName);
     }
 
     private boolean externalStatusMatchesExternalPaymentId() {

--- a/src/main/java/uk/gov/caz/psr/model/PaymentStatus.java
+++ b/src/main/java/uk/gov/caz/psr/model/PaymentStatus.java
@@ -15,6 +15,11 @@ public class PaymentStatus {
    * The unique payment ID coming from GOV UK Pay services.
    */
   String externalId;
+  
+  /**
+   * The internal reference for the payment.
+   */
+  Long paymentReference;
 
   /**
    * Status of the payment.

--- a/src/main/java/uk/gov/caz/psr/model/info/PaymentInfo.java
+++ b/src/main/java/uk/gov/caz/psr/model/info/PaymentInfo.java
@@ -30,6 +30,9 @@ public class PaymentInfo {
   @Enumerated(EnumType.STRING)
   private ExternalPaymentStatus externalPaymentStatus;
 
+  @Column(name = "central_reference_number")
+  private Long referenceNumber;
+
   @Column(name = "payment_submitted_timestamp")
   private LocalDateTime submittedTimestamp;
 }

--- a/src/main/java/uk/gov/caz/psr/repository/ExternalPaymentsRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/ExternalPaymentsRepository.java
@@ -199,7 +199,7 @@ public class ExternalPaymentsRepository {
   private CreateCardPaymentRequest buildCreateBody(Payment payment, String returnUrl) {
     return CreateCardPaymentRequest.builder().amount(payment.getTotalPaid())
         .description("Driving in a Clean Air Zone charge")
-        .reference(payment.getId().toString())
+        .reference(payment.getReferenceNumber().toString())
         .returnUrl(returnUrl).build();
   }
 

--- a/src/main/java/uk/gov/caz/psr/repository/PaymentStatusRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/PaymentStatusRepository.java
@@ -25,7 +25,8 @@ public class PaymentStatusRepository {
   static final String SELECT_BY_ENTRY_DATE_AND_VRN_AND_CAZ_ID_SQL = "SELECT "
       + "vehicle_entrant_payment.payment_status, "
       + "vehicle_entrant_payment.case_reference, "
-      + "payment.payment_provider_id "
+      + "payment.payment_provider_id, "
+      + "payment.central_reference_number "
       + "FROM vehicle_entrant_payment "
       + "INNER JOIN payment on vehicle_entrant_payment.payment_id = payment.payment_id "
       + "WHERE vehicle_entrant_payment.caz_id = ? AND "
@@ -68,6 +69,7 @@ public class PaymentStatusRepository {
     public PaymentStatus mapRow(ResultSet resultSet, int i) throws SQLException {
       return PaymentStatus.builder()
           .externalId(resultSet.getString("payment_provider_id"))
+          .paymentReference(resultSet.getLong("central_reference_number"))
           .status(InternalPaymentStatus.valueOf(
               resultSet.getString("payment_status")))
           .caseReference(resultSet.getString("case_reference"))

--- a/src/main/java/uk/gov/caz/psr/service/PaymentReceiptService.java
+++ b/src/main/java/uk/gov/caz/psr/service/PaymentReceiptService.java
@@ -2,7 +2,9 @@ package uk.gov.caz.psr.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Collections;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,15 +34,23 @@ public class PaymentReceiptService {
    * @return SendEmailRequest
    * @throws JsonProcessingException if the amount cannot be serialized into a json string
    */
-  public SendEmailRequest buildSendEmailRequest(String email, double amount)
+  public SendEmailRequest buildSendEmailRequest(String email, double amount, 
+      String cazName, String reference, String vrn)
       throws JsonProcessingException {
     return SendEmailRequest.builder().emailAddress(email)
-        .personalisation(createPersonalisationPayload(amount)).templateId(templateId).build();
+        .personalisation(createPersonalisationPayload(amount, cazName, reference, vrn))
+        .templateId(templateId).build();
   }
 
-  private String createPersonalisationPayload(double amount) throws JsonProcessingException {
-    Map<String, String> personalisationMap = Collections.singletonMap("amount",
-        String.format(Locale.UK, "%.2f", amount));
+  private String createPersonalisationPayload(double amount, String cazName, 
+      String reference, String vrn) throws JsonProcessingException {
+    Map<String, String> personalisationMap = new HashMap<String, String>();    
+    personalisationMap.put("amount", String.format(Locale.UK, "%.2f", amount));
+    personalisationMap.put("caz", cazName);
+    personalisationMap.put("date", 
+        LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd MMMM YYYY")));
+    personalisationMap.put("reference", reference);
+    personalisationMap.put("vrn", vrn);
     return objectMapper.writeValueAsString(personalisationMap);
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/ReconcilePaymentStatusService.java
+++ b/src/main/java/uk/gov/caz/psr/service/ReconcilePaymentStatusService.java
@@ -19,7 +19,7 @@ import uk.gov.caz.psr.util.GetPaymentResultConverter;
 @Service
 @AllArgsConstructor
 @Slf4j
-public class GetAndUpdatePaymentsService {
+public class ReconcilePaymentStatusService {
 
   private final ExternalPaymentsRepository externalPaymentsRepository;
   private final PaymentRepository internalPaymentsRepository;
@@ -34,14 +34,17 @@ public class GetAndUpdatePaymentsService {
    *
    * @throws NullPointerException if {@code id} is null
    */
-  public Optional<Payment> getExternalPaymentAndUpdateStatus(UUID id) {
+  public Optional<Payment> reconcilePaymentStatus(UUID id, String cleanAirZoneName) {
     Preconditions.checkNotNull(id, "ID cannot be null");
 
-    Payment payment = internalPaymentsRepository.findById(id).orElse(null);
+    Payment internalPayment = internalPaymentsRepository.findById(id).orElse(null);
+    Payment payment;
 
-    if (payment == null) {
+    if (internalPayment == null) {
       log.warn("Payment '{}' is absent in the database", id);
       return Optional.empty();
+    } else {
+      payment = internalPayment.toBuilder().cleanAirZoneName(cleanAirZoneName).build();
     }
 
     String externalPaymentId = payment.getExternalId();

--- a/src/main/java/uk/gov/caz/psr/service/listener/PaymentReceiptSender.java
+++ b/src/main/java/uk/gov/caz/psr/service/listener/PaymentReceiptSender.java
@@ -37,10 +37,14 @@ public class PaymentReceiptSender {
     double totalAmount = currencyFormatter.parsePennies(payment.getTotalPaid());
 
     log.info("Processing email event for payment with ID: {}", payment.getId());
-
+    
+    String cazName = payment.getCleanAirZoneName();
+    String vrn = payment.getVehicleEntrantPayments().iterator().next().getVrn();
+    
     try {
       SendEmailRequest sendEmailRequest =
-          paymentReceiptService.buildSendEmailRequest(payment.getEmailAddress(), totalAmount);
+          paymentReceiptService.buildSendEmailRequest(payment.getEmailAddress(), totalAmount, 
+              cazName, payment.getReferenceNumber().toString(), vrn);
       messagingClient.publishMessage(sendEmailRequest);
     } catch (Exception e) {
       log.error("Payment receipt not sent to recipient with payment ID: {}", payment.getId(), e);

--- a/src/main/java/uk/gov/caz/psr/util/VehicleEntrantPaymentInfoConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/VehicleEntrantPaymentInfoConverter.java
@@ -80,6 +80,7 @@ public class VehicleEntrantPaymentInfoConverter {
   private SinglePaymentInfo toSinglePaymentInfo(PaymentInfo paymentInfo,
       List<VehicleEntrantPaymentInfo> entrantPaymentInfoList) {
     return SinglePaymentInfo.builder()
+        .cazPaymentReference(paymentInfo.getReferenceNumber())
         .paymentDate(toLocalDate(paymentInfo.getSubmittedTimestamp()))
         .paymentProviderId(paymentInfo.getExternalId())
         .totalPaid(currencyFormatter.parsePenniesToBigDecimal(paymentInfo.getTotalPaid()))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,7 @@ swagger:
     descriptions:
       payment-status:
         payment-status: Status of the payment. Can be either 'paid', 'refunded' or 'chargeback'
+        caz-payment-reference: The central reference for the payment
         payment-provider-id: GOV.UK Pay unique payment identifier
         case-reference: >-
           A unique identifier that provides traceability between the central CAZ Service and Local Authority case management
@@ -62,6 +63,7 @@ swagger:
         results: An array containig details about payments of queried VRNs
         vrn: Vehicle registration number
         payments: An array containing information about particular payments of the given VRN
+        caz-payment-reference: The central reference for the payment
         payment-provider-id: GOV.UK Pay unique payment identifier
         total-paid: >-
           The total GBP value of the payment linked to the paymentProviderId.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -134,7 +134,8 @@ swagger:
         clean-zone-id: Clean Air Zone identifier
         amount: Amount to pay
         return-url: Front end URL used as return URL after payment.
-
+      payments-get-status:
+        clean-air-zone-name: Clean Air Zone name
 
   operations:
     payments:

--- a/src/main/resources/db/changelog/changes/0003-1.0-add_central_reference_number_sequence.yaml
+++ b/src/main/resources/db/changelog/changes/0003-1.0-add_central_reference_number_sequence.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0003-1.0
+      author: informed
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            sequenceExists:
+              schemaName: public
+              sequenceName: central_reference
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            encoding: utf8
+            endDelimiter: ;GO
+            path: ../rawSql/0003-1.0-add_central_reference_number_seqence.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true

--- a/src/main/resources/db/changelog/rawSql/0003-1.0-add_central_reference_number_seqence.sql
+++ b/src/main/resources/db/changelog/rawSql/0003-1.0-add_central_reference_number_seqence.sql
@@ -1,0 +1,2 @@
+CREATE SEQUENCE IF NOT EXISTS public.reference_number START WITH 1627;
+ALTER TABLE public.payment ADD COLUMN central_reference_number bigint DEFAULT nextval('public.reference_number') NOT NULL;

--- a/src/test/java/uk/gov/caz/psr/controller/PaymentsControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/PaymentsControllerTest.java
@@ -30,7 +30,7 @@ import uk.gov.caz.correlationid.Configuration;
 import uk.gov.caz.psr.dto.InitiatePaymentRequest;
 import uk.gov.caz.psr.model.Payment;
 import uk.gov.caz.psr.repository.ExternalPaymentsRepository;
-import uk.gov.caz.psr.service.GetAndUpdatePaymentsService;
+import uk.gov.caz.psr.service.ReconcilePaymentStatusService;
 import uk.gov.caz.psr.service.InitiatePaymentService;
 import uk.gov.caz.psr.util.TestObjectFactory.Payments;
 
@@ -42,7 +42,7 @@ class PaymentsControllerTest {
   private InitiatePaymentService initiatePaymentService;
 
   @MockBean
-  private GetAndUpdatePaymentsService getAndUpdatePaymentsService;
+  private ReconcilePaymentStatusService reconcilePaymentStatusService;
 
   @MockBean
   private ExternalPaymentsRepository externalPaymentsRepository;

--- a/src/test/java/uk/gov/caz/psr/repository/ExternalPaymentsRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/ExternalPaymentsRepositoryTest.java
@@ -177,7 +177,7 @@ class ExternalPaymentsRepositoryTest {
 
     private Payment createPayment(UUID paymentId) {
       return Payments.forDays(Arrays.asList(LocalDate.now(), LocalDate.now().plusDays(1)),
-          paymentId);
+          paymentId).toBuilder().referenceNumber((long) 1).build();
     }
   }
 

--- a/src/test/java/uk/gov/caz/psr/repository/PaymentRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/PaymentRepositoryTest.java
@@ -98,7 +98,7 @@ class PaymentRepositoryTest {
     private Payment paymentWithTwoDifferentVehicleEntrantStatuses() {
       Payment payment =
           Payments.forDays(Arrays.asList(LocalDate.now(), LocalDate.now().plusDays(1)),
-              UUID.randomUUID(), "ext-id", null);
+              null, null, null);
       Iterator<VehicleEntrantPayment> it = payment.getVehicleEntrantPayments().iterator();
       List<VehicleEntrantPayment> updatedVehicleEntrantPayments =
           Arrays.asList(InternalPaymentStatus.PAID, InternalPaymentStatus.CHARGEBACK).stream()

--- a/src/test/java/uk/gov/caz/psr/service/PaymentReceiptServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/PaymentReceiptServiceTest.java
@@ -2,9 +2,11 @@ package uk.gov.caz.psr.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-
+import static org.junit.Assert.assertTrue;
+import java.util.HashMap;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.mapping.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.caz.psr.dto.SendEmailRequest;
@@ -13,6 +15,7 @@ public class PaymentReceiptServiceTest {
 
   private PaymentReceiptService paymentReceiptService;
   private String templateId = "test-template-id";
+  private ObjectMapper om = new ObjectMapper();
 
   @BeforeEach
   void init() {
@@ -32,12 +35,18 @@ public class PaymentReceiptServiceTest {
     String testEmail = "test@test.com";
 
     // when
-    SendEmailRequest request = paymentReceiptService.buildSendEmailRequest(testEmail, 1.0);
+    SendEmailRequest request = paymentReceiptService.buildSendEmailRequest(testEmail, 1.0, "Leeds", "1001", "CAS300");
 
     // then
     assertNotNull(request);
     assertEquals(testEmail, request.getEmailAddress());
-    assertEquals("{\"amount\":\"1.00\"}", request.getPersonalisation());
+    
+    HashMap<String, String> personalisation = om.readValue(request.getPersonalisation(), HashMap.class);
+    assertTrue(personalisation.containsKey("amount"));
+    assertTrue(personalisation.containsKey("date"));
+    assertTrue(personalisation.containsKey("reference"));
+    assertTrue(personalisation.containsKey("vrn"));
+    assertTrue(personalisation.containsKey("caz"));
     assertEquals(templateId, request.getTemplateId());
   }
 

--- a/src/test/java/uk/gov/caz/psr/service/ReconcilePaymentStatusServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/ReconcilePaymentStatusServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.caz.psr.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -30,7 +29,7 @@ import uk.gov.caz.psr.util.TestObjectFactory;
 import uk.gov.caz.psr.util.TestObjectFactory.ExternalPaymentDetailsFactory;
 
 @ExtendWith(MockitoExtension.class)
-class GetAndUpdatePaymentsServiceTest {
+class ReconcilePaymentStatusServiceTest {
 
   @Mock
   private PaymentRepository internalPaymentsRepository;
@@ -48,9 +47,10 @@ class GetAndUpdatePaymentsServiceTest {
   private GetPaymentResultConverter getPaymentResultConverter;
 
   @InjectMocks
-  private GetAndUpdatePaymentsService getAndUpdatePaymentsService;
+  private ReconcilePaymentStatusService reconcilePaymentStatusService;
 
   private final UUID cazIdentifier = UUID.fromString("ab3e9f4b-4076-4154-b6dd-97c5d4800b47");
+  private final static String CLEAN_AIR_ZONE_NAME = "Leeds";
 
   @Test
   public void shouldThrowNullPointerExceptionWhenPassedNullValue() {
@@ -59,7 +59,7 @@ class GetAndUpdatePaymentsServiceTest {
 
     // when
     Throwable throwable =
-        catchThrowable(() -> getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(id));
+        catchThrowable(() -> reconcilePaymentStatusService.reconcilePaymentStatus(id, CLEAN_AIR_ZONE_NAME));
 
     assertThat(throwable).isInstanceOf(NullPointerException.class).hasMessage("ID cannot be null");
   }
@@ -74,7 +74,7 @@ class GetAndUpdatePaymentsServiceTest {
 
     // when
     Throwable throwable = catchThrowable(
-        () -> getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId));
+        () -> reconcilePaymentStatusService.reconcilePaymentStatus(paymentId, CLEAN_AIR_ZONE_NAME));
 
     // then
     assertThat(throwable).isInstanceOf(IllegalStateException.class)
@@ -89,7 +89,7 @@ class GetAndUpdatePaymentsServiceTest {
 
     // when
     Optional<Payment> result =
-        getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+        reconcilePaymentStatusService.reconcilePaymentStatus(paymentId, CLEAN_AIR_ZONE_NAME);
 
     // then
     assertThat(result).isEmpty();
@@ -106,7 +106,7 @@ class GetAndUpdatePaymentsServiceTest {
 
     // when
     Optional<Payment> result =
-        getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+        reconcilePaymentStatusService.reconcilePaymentStatus(paymentId, CLEAN_AIR_ZONE_NAME);
 
     // then
     assertThat(result).isEmpty();
@@ -119,12 +119,13 @@ class GetAndUpdatePaymentsServiceTest {
     UUID paymentId = UUID.fromString("c56fcd5f-fde6-4d7d-aa3f-8ff192a6244f");
     String externalId = "ext-id";
     Payment payment = mockInternalPaymentWith(paymentId, externalId);
+    payment = payment.toBuilder().cleanAirZoneName(CLEAN_AIR_ZONE_NAME).build();
     mockSameExternalStatusFor(payment);
     mockGetPaymentResultConverter(payment.getExternalPaymentStatus());
 
     // when
     Optional<Payment> result =
-        getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+        reconcilePaymentStatusService.reconcilePaymentStatus(paymentId, CLEAN_AIR_ZONE_NAME);
 
     // then
     assertThat(result).contains(payment);
@@ -142,7 +143,7 @@ class GetAndUpdatePaymentsServiceTest {
     String email = "example@email.com";
     UUID paymentId = UUID.fromString("c56fcd5f-fde6-4d7d-aa3f-8ff192a6244f");
     Payment payment = mockInternalPaymentWith(paymentId, "ext-id",
-        initExternalPaymentDetails.getExternalPaymentStatus(), this.cazIdentifier);
+        initExternalPaymentDetails.getExternalPaymentStatus(), this.cazIdentifier, CLEAN_AIR_ZONE_NAME);
     Payment paymentWithEmail = payment.toBuilder().emailAddress(email).build();
     mockSuccessStatusFor(payment, email);
     mockStatusUpdaterWithSuccess(paymentWithEmail, newExternalPaymentDetails);
@@ -150,7 +151,7 @@ class GetAndUpdatePaymentsServiceTest {
 
     // when
     Optional<Payment> result =
-        getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId);
+        reconcilePaymentStatusService.reconcilePaymentStatus(paymentId, CLEAN_AIR_ZONE_NAME);
 
     // then
     assertThat(result).contains(paymentWithEmail);
@@ -165,12 +166,12 @@ class GetAndUpdatePaymentsServiceTest {
 
     UUID paymentId = UUID.fromString("c56fcd5f-fde6-4d7d-aa3f-8ff192a6244f");
     mockInternalPaymentWith(paymentId, "ext-id",
-        initExternalPaymentDetails.getExternalPaymentStatus(), null);
+        initExternalPaymentDetails.getExternalPaymentStatus(), null, CLEAN_AIR_ZONE_NAME);
     
 
     // when
     Throwable throwable =
-        catchThrowable(() -> getAndUpdatePaymentsService.getExternalPaymentAndUpdateStatus(paymentId));
+        catchThrowable(() -> reconcilePaymentStatusService.reconcilePaymentStatus(paymentId,CLEAN_AIR_ZONE_NAME));
 
     assertThat(throwable).isInstanceOf(IllegalArgumentException.class).hasMessage("Vehicle entrant payments should not be empty");
   }
@@ -182,9 +183,9 @@ class GetAndUpdatePaymentsServiceTest {
   }
 
   private Payment mockInternalPaymentWith(UUID paymentId, String externalId,
-      ExternalPaymentStatus newStatus, UUID cazIdentifier) {
+      ExternalPaymentStatus newStatus, UUID cazIdentifier, String cazName) {
     Payment payment = TestObjectFactory.Payments.forRandomDaysWithId(paymentId, externalId, cazIdentifier)
-        .toBuilder().externalPaymentStatus(newStatus).build();
+        .toBuilder().externalPaymentStatus(newStatus).cleanAirZoneName(cazName).build();
     mockInternalPaymentInDatabase(paymentId, payment, cazIdentifier);
     return payment;
   }

--- a/src/test/java/uk/gov/caz/psr/service/listener/PaymentReceiptSenderTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/listener/PaymentReceiptSenderTest.java
@@ -99,7 +99,6 @@ public class PaymentReceiptSenderTest {
     when(currencyFormatter.parsePennies(ANY_AMOUNT)).thenReturn(amount);
     when(paymentReceiptService.buildSendEmailRequest(ANY_VALID_EMAIL, amount))
         .thenThrow(new JsonMappingException(null, "test exception"));
-    when(currencyFormatter.parsePennies(ANY_AMOUNT)).thenReturn((double) ANY_AMOUNT);
 
     // when
     paymentReceiptSender.onPaymentStatusUpdated(event);

--- a/src/test/java/uk/gov/caz/psr/service/listener/PaymentReceiptSenderTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/listener/PaymentReceiptSenderTest.java
@@ -21,21 +21,28 @@ import uk.gov.caz.psr.dto.SendEmailRequest;
 import uk.gov.caz.psr.messaging.MessagingClient;
 import uk.gov.caz.psr.model.Payment;
 import uk.gov.caz.psr.model.PaymentMethod;
+import uk.gov.caz.psr.model.VehicleEntrantPayment;
 import uk.gov.caz.psr.model.events.PaymentStatusUpdatedEvent;
 import uk.gov.caz.psr.service.PaymentReceiptService;
 import uk.gov.caz.psr.util.CurrencyFormatter;
+import uk.gov.caz.psr.util.TestObjectFactory.VehicleEntrantPayments;
 
 @ExtendWith(MockitoExtension.class)
 public class PaymentReceiptSenderTest {
 
   private static final String ANY_VALID_EMAIL = "test@test.com";
   private static final int ANY_AMOUNT = 800;
+  private static final String ANY_CAZ = "";
+  private static final Long ANY_REFERENCE = (long) 1001;
+  private static final String ANY_VRN = "VRN123";
   private static final Payment ANY_PAYMENT = Payment.builder()
       .id(UUID.randomUUID())
       .paymentMethod(PaymentMethod.CREDIT_DEBIT_CARD)
+      .referenceNumber(ANY_REFERENCE)
       .totalPaid(ANY_AMOUNT)
-      .vehicleEntrantPayments(Collections.emptyList())
-      .emailAddress(ANY_VALID_EMAIL).build();
+      .vehicleEntrantPayments(Collections.singletonList(VehicleEntrantPayments.anyPaid()))
+      .emailAddress(ANY_VALID_EMAIL)
+      .cleanAirZoneName(ANY_CAZ).build();
 
   @Mock
   CurrencyFormatter currencyFormatter;
@@ -81,7 +88,7 @@ public class PaymentReceiptSenderTest {
     SendEmailRequest sendEmailRequest = anyValidRequest();
     PaymentStatusUpdatedEvent event = new PaymentStatusUpdatedEvent(this, ANY_PAYMENT);
     when(currencyFormatter.parsePennies(ANY_AMOUNT)).thenReturn(8.0);
-    when(paymentReceiptService.buildSendEmailRequest(ANY_VALID_EMAIL, 8.0))
+    when(paymentReceiptService.buildSendEmailRequest(ANY_VALID_EMAIL, 8.0, ANY_CAZ, ANY_REFERENCE.toString(), ANY_VRN))
         .thenReturn(sendEmailRequest);
 
     // when
@@ -97,7 +104,7 @@ public class PaymentReceiptSenderTest {
     PaymentStatusUpdatedEvent event = new PaymentStatusUpdatedEvent(this, ANY_PAYMENT);
     double amount = 8.0;
     when(currencyFormatter.parsePennies(ANY_AMOUNT)).thenReturn(amount);
-    when(paymentReceiptService.buildSendEmailRequest(ANY_VALID_EMAIL, amount))
+    when(paymentReceiptService.buildSendEmailRequest(ANY_VALID_EMAIL, amount, ANY_CAZ, ANY_REFERENCE.toString(), ANY_VRN))
         .thenThrow(new JsonMappingException(null, "test exception"));
 
     // when
@@ -113,7 +120,7 @@ public class PaymentReceiptSenderTest {
     PaymentStatusUpdatedEvent event = new PaymentStatusUpdatedEvent(this, ANY_PAYMENT);
     SendEmailRequest sendEmailRequest = anyValidRequest();
     when(currencyFormatter.parsePennies(ANY_AMOUNT)).thenReturn(8.0);
-    when(paymentReceiptService.buildSendEmailRequest(ANY_VALID_EMAIL, 8.0))
+    when(paymentReceiptService.buildSendEmailRequest(ANY_VALID_EMAIL, 8.0, ANY_CAZ, ANY_REFERENCE.toString(), ANY_VRN))
         .thenReturn(sendEmailRequest);
 
     // when

--- a/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
+++ b/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
@@ -288,8 +288,8 @@ public class TestObjectFactory {
     }
 
     public static PaymentStatus with(InternalPaymentStatus internalPaymentStatus,
-        String caseReference, String externalId) {
-      return PaymentStatus.builder().caseReference(caseReference).status(internalPaymentStatus)
+        String caseReference, String externalId, Long paymentReference) {
+      return PaymentStatus.builder().caseReference(caseReference).paymentReference(paymentReference).status(internalPaymentStatus)
           .externalId(externalId).build();
     }
   }


### PR DESCRIPTION
- Creates a new sequence in the public schema which increments, from a seed value, a reference in the Payment table.
- Sends this reference through to Gov.UK Pay
- Returns the Gov.UK Pay ID and the central reference number from the initiate payment endpoint
- Adds parameters needed to build new Notify template for payments receipt
- Adds reference to the response received from GET requests to the Charge Settlement API.

**Needs to be merged in tandem with corresponding PR in the Payments UI**