### PR TITLE
[CAZ-1723] Update Payment Status - when EntrantPayment is missing

### DIFF
--- a/src/it/resources/data/sql/add-payments-for-payment-status.sql
+++ b/src/it/resources/data/sql/add-payments-for-payment-status.sql
@@ -1,8 +1,8 @@
 INSERT INTO caz_payment.t_payment(
-	payment_id, payment_method, payment_provider_id, total_paid, payment_submitted_timestamp, payment_authorised_timestamp, central_reference_number)
+	payment_id, payment_method, payment_provider_status, payment_provider_id, total_paid, payment_submitted_timestamp, payment_authorised_timestamp, central_reference_number)
 	VALUES
-	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', '12345test', 100, now(), now(), 3000),
-	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', '54321test', 200, now(), now(), 3001);
+	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', 'SUCCESS', '12345test', 100, now(), now(), 3000),
+	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', 'SUCCESS', '54321test', 200, now(), now(), 3001);
 
 INSERT INTO caz_payment.t_clean_air_zone_entrant_payment(
 	clean_air_zone_entrant_payment_id, vrn, clean_air_zone_id, travel_date, charge, tariff_code, payment_status, case_reference, update_actor)

--- a/src/it/resources/data/sql/add-payments.sql
+++ b/src/it/resources/data/sql/add-payments.sql
@@ -6,10 +6,10 @@ INSERT INTO caz_payment.t_payment(
 	  ('dabc1391-ff31-427a-8000-69037deb2d3a', 'CREDIT_DEBIT_CARD', '98765test', 100, now(), now());
 
 INSERT INTO caz_payment.t_clean_air_zone_entrant_payment(
-	clean_air_zone_entrant_payment_id, vrn, clean_air_zone_id, travel_date, charge, payment_status)
+	clean_air_zone_entrant_payment_id, vrn, clean_air_zone_id, travel_date, charge, payment_status, update_actor)
 	VALUES
-	  ('43ea77cc-93cb-4df3-b731-5244c0de9cc8', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-01', 50, 'PAID'),
-	  ('688f8278-2f0f-4710-bb7c-6b0cca04c1bc', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 50, 'PAID'),
-	  ('9cc2dd1a-905e-4eaf-af85-0b14f95aab89', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 100, 'PAID'),
-	  ('00136ccf-e41b-4ce2-b044-7616aa589aa2', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 100, 'PAID'),
-	  ('21b7049d-b978-482f-a882-4de6bb9d699c', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-04', 100, 'PAID');
+	  ('43ea77cc-93cb-4df3-b731-5244c0de9cc8', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-01', 50, 'PAID', 'VCCS_API'),
+	  ('688f8278-2f0f-4710-bb7c-6b0cca04c1bc', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 50, 'PAID', 'VCCS_API'),
+	  ('9cc2dd1a-905e-4eaf-af85-0b14f95aab89', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 100, 'PAID', 'VCCS_API'),
+	  ('00136ccf-e41b-4ce2-b044-7616aa589aa2', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-04', 100, 'PAID', 'VCCS_API'),
+	  ('21b7049d-b978-482f-a882-4de6bb9d699c', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-05', 100, 'PAID', 'VCCS_API');

--- a/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
+++ b/src/main/java/uk/gov/caz/psr/service/PaymentStatusUpdateService.java
@@ -6,12 +6,14 @@ import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.caz.psr.model.EntrantPayment;
 import uk.gov.caz.psr.model.EntrantPaymentStatusUpdate;
 import uk.gov.caz.psr.model.EntrantPaymentUpdateActor;
 import uk.gov.caz.psr.model.Payment;
 import uk.gov.caz.psr.repository.EntrantPaymentRepository;
 import uk.gov.caz.psr.repository.PaymentRepository;
+import uk.gov.caz.psr.util.EntrantPaymentStatusUpdateConverter;
 
 /**
  * A service which updates {@code paymentStatus} for all found {@link EntrantPayment}.
@@ -23,6 +25,7 @@ public class PaymentStatusUpdateService {
 
   private final EntrantPaymentRepository entrantPaymentRepository;
   private final PaymentRepository paymentRepository;
+  private final EntrantPaymentStatusUpdateConverter entrantPaymentStatusUpdateConverter;
 
   /**
    * Process update of the {@link EntrantPayment} with provided details.
@@ -30,6 +33,7 @@ public class PaymentStatusUpdateService {
    * @param entrantPaymentStatusUpdates list of {@link EntrantPaymentStatusUpdate} which
    *     contains data to find and update {@link EntrantPayment}.
    */
+  @Transactional
   public void process(
       List<EntrantPaymentStatusUpdate> entrantPaymentStatusUpdates) {
     Preconditions.checkNotNull(entrantPaymentStatusUpdates,
@@ -41,13 +45,15 @@ public class PaymentStatusUpdateService {
       if (entrantPayment.isPresent()) {
         handleUpdateEntrantPayment(entrantPayment.get(), entrantPaymentStatusUpdate);
       } else {
-        handleNewEntrantPayment();
+        handleNewEntrantPayment(entrantPaymentStatusUpdate);
       }
     }
   }
 
-  private void handleNewEntrantPayment() {
-    // TODO: Implement in CAZ-1723
+  private void handleNewEntrantPayment(EntrantPaymentStatusUpdate entrantPaymentStatusUpdate) {
+    entrantPaymentRepository.insert(makeNewEntrantPayment(entrantPaymentStatusUpdate));
+    log.info("Created new EntrantPayment from the following statusUpdate: {}",
+        entrantPaymentStatusUpdate);
   }
 
   private void handleUpdateEntrantPayment(EntrantPayment entrantPayment,
@@ -62,6 +68,9 @@ public class PaymentStatusUpdateService {
 
     entrantPaymentRepository
         .update(prepareUpdateEntrantPayment(entrantPayment, entrantPaymentStatusUpdate));
+
+    log.info("Updated EntrantPayment from the following statusUpdate: {}",
+        entrantPaymentStatusUpdate);
   }
 
   /**
@@ -79,6 +88,19 @@ public class PaymentStatusUpdateService {
         .caseReference(entrantPaymentStatusUpdate.getCaseReference())
         .updateActor(EntrantPaymentUpdateActor.LA)
         .build();
+  }
+
+  /**
+   * Builds a new instance of {@link EntrantPayment} with attributes assigned by Local Authority,
+   * with zero charge.
+   *
+   * @param statusUpdate {@link EntrantPaymentStatusUpdate} object used to initialize new
+   *     record.
+   * @return entrantPayment {@link EntrantPayment} which is supposed to be persisted in the
+   *     database.
+   */
+  private EntrantPayment makeNewEntrantPayment(EntrantPaymentStatusUpdate statusUpdate) {
+    return entrantPaymentStatusUpdateConverter.convert(statusUpdate);
   }
 
   /**

--- a/src/main/java/uk/gov/caz/psr/util/EntrantPaymentStatusUpdateConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/EntrantPaymentStatusUpdateConverter.java
@@ -1,0 +1,35 @@
+package uk.gov.caz.psr.util;
+
+import org.springframework.stereotype.Component;
+import uk.gov.caz.psr.model.EntrantPayment;
+import uk.gov.caz.psr.model.EntrantPaymentStatusUpdate;
+import uk.gov.caz.psr.model.EntrantPaymentUpdateActor;
+
+/**
+ * Utility class that creates new instance of {@link EntrantPayment} using attributes provided in
+ * {@link EntrantPaymentStatusUpdate} and default attributes which are associated with update-by-LA
+ * context.
+ */
+@Component
+public class EntrantPaymentStatusUpdateConverter {
+
+  /**
+   * Creates new instance of {@link EntrantPayment} based on attributes provided
+   * in {@link EntrantPaymentStatusUpdate}.
+   *
+   * @param statusUpdate from which initial attributes are taken
+   * @return {@link EntrantPayment}
+   */
+  public EntrantPayment convert(EntrantPaymentStatusUpdate statusUpdate) {
+    return EntrantPayment.builder()
+        .vrn(statusUpdate.getVrn())
+        .cleanAirZoneId(statusUpdate.getCleanAirZoneId())
+        .travelDate(statusUpdate.getDateOfCazEntry())
+        .vehicleEntrantCaptured(false)
+        .updateActor(EntrantPaymentUpdateActor.LA)
+        .internalPaymentStatus(statusUpdate.getPaymentStatus())
+        .caseReference(statusUpdate.getCaseReference())
+        .charge(0)
+        .build();
+  }
+}


### PR DESCRIPTION
**Introduced changes:**
* When request `PUT /payment-status` tries to update `EntrantPayment` which does not exist - the record is being created with the proper data.

**Additional info:**
* [Link to CAZ-1723 JIRA Card](https://eaflood.atlassian.net/browse/CAZ-1723)