### PR TITLE
[CAZ-1760] Double payments prevention

### DIFF
--- a/src/it/java/uk/gov/caz/psr/GetPaidEntrantPaymentsTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/GetPaidEntrantPaymentsTestIT.java
@@ -1,0 +1,116 @@
+package uk.gov.caz.psr;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.caz.correlationid.Constants;
+import uk.gov.caz.psr.annotation.IntegrationTest;
+import uk.gov.caz.psr.controller.PaymentsController;
+import uk.gov.caz.psr.dto.PaidPaymentsRequest;
+import uk.gov.caz.psr.dto.PaidPaymentsResponse;
+import uk.gov.caz.psr.dto.PaidPaymentsResponse.PaidPaymentsResult;
+
+@Sql(scripts = "classpath:data/sql/add-payments-for-payment-status.sql",
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:data/sql/clear-all-payments.sql",
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@IntegrationTest
+@AutoConfigureMockMvc
+public class GetPaidEntrantPaymentsTestIT {
+
+  private static final String PATH =
+      PaymentsController.BASE_PATH + "/" + PaymentsController.GET_PAID_VEHICLE_ENTRANTS;
+
+  private static final String VALID_CORRELATION_HEADER = "79b7a48f-27c7-4947-bd1c-670f981843ef";
+  private static final String VALID_CAZ_ID = "b8e53786-c5ca-426a-a701-b14ee74857d4";
+  private static final String VALID_VRN = "ND84VSX";
+  private static final LocalDate VALID_START_DATE = LocalDate.of(2019, 11, 1);
+  private static final LocalDate VALID_END_DATE = LocalDate.of(2019, 11, 5);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  public void shouldReturn400WhenParametersIsMissing() throws Exception {
+    mockMvc.perform(post(PATH)
+        .content(invalidJsonPayload())
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header("x-api-key", VALID_CAZ_ID))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void shouldReturn200WithResultsWhenRequestIsValid() throws Exception {
+    mockMvc.perform(post(PATH)
+        .content(validJsonPayload())
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header("x-api-key", VALID_CAZ_ID))
+        .andExpect(status().isOk())
+        .andExpect(content().json(validJsonResponse()));
+  }
+
+  private String validJsonResponse() {
+    PaidPaymentsResponse response = PaidPaymentsResponse.builder()
+        .results(Arrays.asList(validResult()))
+        .build();
+
+    return toJson(response);
+  }
+
+  private PaidPaymentsResult validResult() {
+    List<LocalDate> paidDates = Arrays.asList(
+        LocalDate.parse("2019-11-01"),
+        LocalDate.parse("2019-11-04")
+    );
+
+    return PaidPaymentsResult.builder()
+        .vrn(VALID_VRN)
+        .paidDates(paidDates)
+        .build();
+  }
+
+  private String validJsonPayload() {
+    PaidPaymentsRequest request = PaidPaymentsRequest.builder()
+        .vrns(Arrays.asList(VALID_VRN))
+        .startDate(VALID_START_DATE)
+        .endDate(VALID_END_DATE)
+        .build();
+
+    return toJson(request);
+  }
+
+  private String invalidJsonPayload() {
+    PaidPaymentsRequest request = PaidPaymentsRequest.builder()
+        .vrns(null)
+        .startDate(null)
+        .endDate(null)
+        .build();
+
+    return toJson(request);
+  }
+
+  @SneakyThrows
+  private String toJson(Object request) {
+    return objectMapper.writeValueAsString(request);
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/controller/PaymentsControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/PaymentsControllerApiSpec.java
@@ -16,10 +16,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import uk.gov.caz.psr.dto.Headers;
 import uk.gov.caz.psr.dto.InitiatePaymentRequest;
 import uk.gov.caz.psr.dto.InitiatePaymentResponse;
+import uk.gov.caz.psr.dto.PaidPaymentsRequest;
+import uk.gov.caz.psr.dto.PaidPaymentsResponse;
 import uk.gov.caz.psr.dto.PaymentStatusResponse;
 import uk.gov.caz.psr.dto.ReconcilePaymentRequest;
 import uk.gov.caz.psr.dto.ReconcilePaymentResponse;
@@ -59,4 +63,33 @@ public interface PaymentsControllerApiSpec {
   @ResponseStatus(HttpStatus.OK)
   ResponseEntity<ReconcilePaymentResponse> reconcilePaymentStatus(
       @PathVariable UUID id, @RequestBody ReconcilePaymentRequest request);
+
+  /**
+   * Allows User to fetch information about already paid days in specific CAZ in order to prevent
+   * him from paying for the same day more than one time. Upon completion of this operation the
+   * list of provided VRNs along with list of paid days is returned.
+   */
+  @ApiOperation(
+      value = "${swagger.operations.payments.get-paid-entrants.description}",
+      response = PaidPaymentsResponse.class
+  )
+  @ApiResponses({
+      @ApiResponse(code = 500, message = "Internal Server Error / No message available"),
+      @ApiResponse(code = 405, message = "Method Not Allowed / Request method 'XXX' not supported"),
+      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory "
+          + "element)"),
+      @ApiResponse(code = 429, message = "Too many requests")
+  })
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = X_CORRELATION_ID_HEADER,
+          required = true,
+          value = "UUID formatted string to track the request through the enquiries stack",
+          paramType = "header")
+  })
+  @PostMapping(PaymentsController.GET_PAID_VEHICLE_ENTRANTS)
+  @ResponseStatus(HttpStatus.OK)
+  ResponseEntity<PaidPaymentsResponse> getPaidEntrantPayment(
+      @RequestBody @Valid PaidPaymentsRequest paymentsRequest,
+      @RequestHeader(Headers.X_API_KEY) UUID cleanAirZoneId);
+
 }

--- a/src/main/java/uk/gov/caz/psr/controller/exception/InvalidRequestPayloadException.java
+++ b/src/main/java/uk/gov/caz/psr/controller/exception/InvalidRequestPayloadException.java
@@ -1,0 +1,16 @@
+package uk.gov.caz.psr.controller.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import uk.gov.caz.ApplicationRuntimeException;
+
+/**
+ * Exception which is thrown when server receives request with invalid parameters.
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidRequestPayloadException extends ApplicationRuntimeException {
+
+  public InvalidRequestPayloadException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/dto/PaidPaymentsRequest.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaidPaymentsRequest.java
@@ -1,0 +1,67 @@
+package uk.gov.caz.psr.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import lombok.Builder;
+import lombok.Value;
+import uk.gov.caz.psr.controller.exception.InvalidRequestPayloadException;
+import uk.gov.caz.psr.util.MapPreservingOrderBuilder;
+
+/**
+ * Class that represents the incoming JSON when client asks for days that are already paid.
+ */
+@Value
+@Builder
+public class PaidPaymentsRequest {
+
+  /**
+   * First day in date range in which the payments are going to be checked.
+   */
+  @ApiModelProperty(value = "${swagger.model.descriptions.paid-payments-request.start-date}")
+  LocalDate startDate;
+
+  /**
+   * Last day in date range in which the payments are going to be checked.
+   */
+  @ApiModelProperty(value = "${swagger.model.descriptions.paid-payments-request.end-date}")
+  LocalDate endDate;
+
+  /**
+   * List of VRNs for which the payments check is going to be done.
+   */
+  @ApiModelProperty(value = "${swagger.model.descriptions.paid-payments-request.vrns}")
+  List<String> vrns;
+
+  private static final Map<Function<PaidPaymentsRequest, Boolean>, String> validators =
+      MapPreservingOrderBuilder.<Function<PaidPaymentsRequest, Boolean>, String>builder()
+          .put(paidPaymentsRequest -> paidPaymentsRequest.startDate != null,
+              "startDate cannot be null.")
+          .put(paidPaymentsRequest -> paidPaymentsRequest.endDate != null,
+              "endDate cannot be null.")
+          .put(paidPaymentsRequest -> paidPaymentsRequest.startDate
+                  .isBefore(paidPaymentsRequest.endDate) || paidPaymentsRequest.startDate
+                  .isEqual(paidPaymentsRequest.endDate),
+              "endDate cannot be before startDate.")
+          .put(paidPaymentsRequest -> paidPaymentsRequest.vrns != null,
+              "VRNs cannot be blank.")
+          .put(paidPaymentsRequest -> !paidPaymentsRequest.vrns.isEmpty(),
+              "VRNs cannot be empty.")
+          .build();
+
+  /**
+   * Public method that validates given object and throws exceptions if validation doesn't pass.
+   */
+  public void validate() {
+    validators.forEach((validator, message) -> {
+      boolean isValid = validator.apply(this);
+
+      if (!isValid) {
+        throw new InvalidRequestPayloadException(message);
+      }
+    });
+  }
+}
+

--- a/src/main/java/uk/gov/caz/psr/dto/PaidPaymentsResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaidPaymentsResponse.java
@@ -1,0 +1,80 @@
+package uk.gov.caz.psr.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import io.swagger.annotations.ApiModelProperty;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Value;
+import uk.gov.caz.psr.model.EntrantPayment;
+
+/**
+ * Class that represents the returned JSON when client asks for days that are already paid.
+ */
+@Value
+@Builder
+public class PaidPaymentsResponse {
+
+  /**
+   * Collection of VRNs and dates which are already paid in a given date range.
+   */
+  @ApiModelProperty(value = "${swagger.model.descriptions.paid-payments-response.results}")
+  List<PaidPaymentsResult> results;
+
+  /**
+   * Converts provided collection to {@link PaidPaymentsResponse}.
+   */
+  public static PaidPaymentsResponse from(Map<String, List<EntrantPayment>> results) {
+    List<PaidPaymentsResult> mappedResults = results.entrySet()
+        .stream()
+        .map(entry -> buildPaidPaymentResultFrom(entry.getKey(), entry.getValue()))
+        .collect(Collectors.toList());
+
+    return PaidPaymentsResponse.builder().results(mappedResults).build();
+  }
+
+  /**
+   * Builds {@link PaidPaymentsResult} based on provided VRN and list of {@link EntrantPayment}.
+   */
+  private static PaidPaymentsResult buildPaidPaymentResultFrom(String vrn,
+      List<EntrantPayment> entrantPayments) {
+    return PaidPaymentsResult.builder()
+        .vrn(vrn)
+        .paidDates(collectTravelDates(entrantPayments)).build();
+  }
+
+  /**
+   * Maps list of {@link EntrantPayment} to list of its travel date.
+   */
+  private static List<LocalDate> collectTravelDates(List<EntrantPayment> entrantPayments) {
+    return entrantPayments
+        .stream()
+        .map(EntrantPayment::getTravelDate)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Class that represents the information about paid dates for a specific VRN and which is returned
+   * to User in {@link PaidPaymentsResponse}.
+   */
+  @Value
+  @Builder
+  public static class PaidPaymentsResult {
+
+    /**
+     * A VRN for which the list of paid days is being returned.
+     */
+    @ApiModelProperty(value = "${swagger.model.descriptions.paid-payments-result.vrn}")
+    String vrn;
+
+    /**
+     * A list of days which are already paid.
+     */
+    @ApiModelProperty(value = "${swagger.model.descriptions.paid-payments-result.paid-dates}")
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+    List<LocalDate> paidDates;
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/service/GetPaidEntrantPaymentsService.java
+++ b/src/main/java/uk/gov/caz/psr/service/GetPaidEntrantPaymentsService.java
@@ -1,0 +1,49 @@
+package uk.gov.caz.psr.service;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.caz.psr.model.EntrantPayment;
+import uk.gov.caz.psr.repository.EntrantPaymentRepository;
+
+/**
+ * Class responsible for fetching PAID EntrantPayments for provided VRNs in provided CAZ ID and
+ * returning it.
+ */
+@Service
+@AllArgsConstructor
+public class GetPaidEntrantPaymentsService {
+
+  private final EntrantPaymentRepository entrantPaymentRepository;
+
+  /**
+   * Method receives a collection of VRNs, date range and CleanAirZone ID for which it is supposed
+   * to fetch collection of PAID {@link EntrantPayment}, and then return information which VRNs in
+   * provided CAZ has already paid for the entrance.
+   *
+   * @param vrns provided list of VRNs.
+   * @param startDate first day in date range.
+   * @param endDate last day in date range.
+   * @param cleanAirZoneId CAZ in which the payments are checked.
+   * @return Map with VRN as a key and list of {@link EntrantPayment} as value.
+   */
+  public Map<String,List<EntrantPayment>> getResults(List<String> vrns, LocalDate startDate,
+      LocalDate endDate, UUID cleanAirZoneId) {
+    Map<String, List<EntrantPayment>> results = new HashMap<>();
+
+    for (String vrn : vrns) {
+      List<EntrantPayment> paidEntrantPaymentsForVrn = entrantPaymentRepository
+          .findAllPaidByVrnAndDateRangeAndCazId(vrn, startDate, endDate, cleanAirZoneId);
+
+      if (!paidEntrantPaymentsForVrn.isEmpty()) {
+        results.put(vrn, paidEntrantPaymentsForVrn);
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/util/MapPreservingOrderBuilder.java
+++ b/src/main/java/uk/gov/caz/psr/util/MapPreservingOrderBuilder.java
@@ -1,0 +1,40 @@
+package uk.gov.caz.psr.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Helper class that builds special kind of map that preserves order.
+ */
+public class MapPreservingOrderBuilder<A, B> {
+  private final LinkedHashMap<A, B> map;
+
+  /**
+   * Internal constructor for MapPreservingOrderBuilder class.
+   */
+  private MapPreservingOrderBuilder(LinkedHashMap<A, B> map) {
+    this.map = map;
+  }
+
+  /**
+   * Static public constructor that is used to initialize MapPreservingOrderBuilder.
+   */
+  public static <A, B> MapPreservingOrderBuilder<A, B> builder() {
+    return new MapPreservingOrderBuilder<>(new LinkedHashMap<>());
+  }
+
+  /**
+   * Method that allows to append value into the map.
+   */
+  public MapPreservingOrderBuilder<A, B> put(A key, B value) {
+    map.put(key, value);
+    return this;
+  }
+
+  /**
+   * Method that returns Map that preserves order of elements.
+   */
+  public Map<A, B> build() {
+    return map;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,6 +141,15 @@ swagger:
         return-url: Front end URL used as return URL after payment.
       payments-get-status:
         clean-air-zone-name: Clean Air Zone name
+      paid-payments-request:
+        start-date: First day in date range in which the payments are going to be checked.
+        end-date: Last day in date range in which the payments are going to be checked.
+        vrns: List of VRNs for which the payments check is going to be done.
+      paid-payments-result:
+        vrn: A VRN for which the list of paid days is being returned.
+        paid-dates: A list of days which are already paid.
+      paid-payments-response:
+        results: Collection of VRNs and dates which are already paid in a given date range.
 
   operations:
     payments:
@@ -148,6 +157,11 @@ swagger:
         description: >-
           Creates (unless it exists) a collection of entries in the database that represents an entrances of a vehicles into a CAZ.
           Upon completion of this operation the collection of caz entrant payments is returned
+      get-paid-entrants:
+        description: >-
+          Fetches information about already paid days in specific CAZ in order to prevent
+          him from paying for the same day more than one time. Upon completion of this operation the
+          list of provided VRNs along with list of paid days is returned.
     charge-settlement:
       payment-status-update:
         description: >-

--- a/src/test/java/uk/gov/caz/psr/controller/PaymentsControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/PaymentsControllerTest.java
@@ -5,39 +5,50 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.caz.correlationid.Constants.X_CORRELATION_ID_HEADER;
 import static uk.gov.caz.psr.controller.PaymentsController.BASE_PATH;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import uk.gov.caz.GlobalExceptionHandlerConfiguration;
+import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.caz.correlationid.Configuration;
+import uk.gov.caz.correlationid.Constants;
 import uk.gov.caz.psr.dto.InitiatePaymentRequest;
+import uk.gov.caz.psr.dto.PaidPaymentsRequest;
+import uk.gov.caz.psr.model.EntrantPayment;
 import uk.gov.caz.psr.model.Payment;
-import uk.gov.caz.psr.repository.ExternalPaymentsRepository;
-import uk.gov.caz.psr.service.ReconcilePaymentStatusService;
+import uk.gov.caz.psr.service.GetPaidEntrantPaymentsService;
 import uk.gov.caz.psr.service.InitiatePaymentService;
+import uk.gov.caz.psr.service.ReconcilePaymentStatusService;
+import uk.gov.caz.psr.util.TestObjectFactory.EntrantPayments;
 import uk.gov.caz.psr.util.TestObjectFactory.Payments;
 
-@ContextConfiguration(classes = {GlobalExceptionHandlerConfiguration.class, Configuration.class,
+@ContextConfiguration(classes = {ExceptionController.class, Configuration.class,
     PaymentsController.class})
 @WebMvcTest
 class PaymentsControllerTest {
+
   @MockBean
   private InitiatePaymentService initiatePaymentService;
 
@@ -45,7 +56,7 @@ class PaymentsControllerTest {
   private ReconcilePaymentStatusService reconcilePaymentStatusService;
 
   @MockBean
-  private ExternalPaymentsRepository externalPaymentsRepository;
+  private GetPaidEntrantPaymentsService getPaidEntrantPaymentsService;
 
   @Autowired
   private MockMvc mockMvc;
@@ -53,130 +64,244 @@ class PaymentsControllerTest {
   @Autowired
   private ObjectMapper objectMapper;
 
+  @BeforeEach
+  public void resetMocks() {
+    Mockito.reset(initiatePaymentService);
+    Mockito.reset(getPaidEntrantPaymentsService);
+  }
+
   private static final List<LocalDate> days =
       Arrays.asList(LocalDate.of(2019, 1, 1), LocalDate.of(2019, 1, 3));
 
   private static final String ANY_CORRELATION_ID = UUID.randomUUID().toString();
 
-  @Test
-  public void missingCorrelationIdShouldResultIn400AndValidMessage() throws Exception {
-    String payload = "";
+  private static final String GET_PAID_PATH = PaymentsController.BASE_PATH + "/"
+      + PaymentsController.GET_PAID_VEHICLE_ENTRANTS;
 
-    mockMvc
-        .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value("Missing request header 'X-Correlation-ID'"));
-    verify(initiatePaymentService, never()).createPayment(any());
+  @Nested
+  class InitiatePayment {
+
+    @Test
+    public void missingCorrelationIdShouldResultIn400AndValidMessage() throws Exception {
+      String payload = "";
+
+      mockMvc
+          .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
+              .accept(MediaType.APPLICATION_JSON))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.message").value("Missing request header 'X-Correlation-ID'"));
+      verify(initiatePaymentService, never()).createPayment(any());
+    }
+
+    @Test
+    public void emptyDaysShouldResultIn400() throws Exception {
+      String payload = paymentRequestWithEmptyDays();
+
+      performRequestWithContent(payload).andExpect(status().isBadRequest());
+      verify(initiatePaymentService, never()).createPayment(any());
+    }
+
+    @Test
+    public void invalidVrnShouldResultIn400() throws Exception {
+      String payload = paymentRequestWithVrn("1234567890123456");
+
+      performRequestWithContent(payload).andExpect(status().isBadRequest());
+      verify(initiatePaymentService, never()).createPayment(any());
+    }
+
+    @Test
+    public void invalidAmountShouldResultIn400() throws Exception {
+      String payload = paymentRequestWithAmount(-1250);
+
+      performRequestWithContent(payload).andExpect(status().isBadRequest());
+      verify(initiatePaymentService, never()).createPayment(any());
+    }
+
+    @Test
+    public void invalidReturnUrlShouldResultIn400() throws Exception {
+      String payload = paymentRequestWithEmptyReturnUrl();
+
+      performRequestWithContent(payload).andExpect(status().isBadRequest());
+      verify(initiatePaymentService, never()).createPayment(any());
+    }
+
+    @Test
+    @Disabled // TODO enable once the whole flow with passing tariffCode from UI is completed
+    public void invalidTariffCodeShouldResultIn400() throws Exception {
+      String payload = paymentRequestWithEmptyTariffCode();
+
+      performRequestWithContent(payload).andExpect(status().isBadRequest());
+      verify(initiatePaymentService, never()).createPayment(any());
+    }
+
+    @Test
+    public void shouldReturnValidResponse() throws Exception {
+      InitiatePaymentRequest requestParams = baseRequestBuilder().build();
+      String payload = toJsonString(requestParams);
+      Payment successfullyCreatedPayment = Payments.existing();
+      given(initiatePaymentService.createPayment(requestParams))
+          .willReturn(successfullyCreatedPayment);
+
+      performRequestWithContent(payload)
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.paymentId").value(successfullyCreatedPayment.getId().toString()))
+          .andExpect(jsonPath("$.nextUrl").value(successfullyCreatedPayment.getNextUrl()));
+      verify(initiatePaymentService).createPayment(requestParams);
+    }
+
+    private ResultActions performRequestWithContent(String payload) throws Exception {
+      return mockMvc.perform(post(BASE_PATH)
+          .content(payload).contentType(MediaType.APPLICATION_JSON)
+          .accept(MediaType.APPLICATION_JSON)
+          .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID));
+    }
+
+    private String paymentRequestWithEmptyDays() {
+      List<LocalDate> emptyDays = Collections.emptyList();
+      InitiatePaymentRequest requestParams = baseRequestBuilder().days(emptyDays).build();
+      return toJsonString(requestParams);
+    }
+
+    private String paymentRequestWithVrn(String vrn) {
+      InitiatePaymentRequest requestParams = baseRequestBuilder().vrn(vrn).build();
+      return toJsonString(requestParams);
+    }
+
+    private String paymentRequestWithAmount(Integer amount) {
+      InitiatePaymentRequest requestParams = baseRequestBuilder().amount(amount).build();
+      return toJsonString(requestParams);
+    }
+
+    private String paymentRequestWithEmptyReturnUrl() {
+      InitiatePaymentRequest requestParams = baseRequestBuilder().returnUrl("").build();
+      return toJsonString(requestParams);
+    }
+
+    private String paymentRequestWithEmptyTariffCode() {
+      InitiatePaymentRequest requestParams = baseRequestBuilder().tariffCode("").build();
+      return toJsonString(requestParams);
+    }
+
+    private InitiatePaymentRequest.InitiatePaymentRequestBuilder baseRequestBuilder() {
+      return InitiatePaymentRequest.builder().cleanAirZoneId(UUID.randomUUID()).days(days)
+          .vrn("TEST123").amount(1050).returnUrl("https://example.return.url")
+          .tariffCode("BCC01-private_car");
+    }
   }
 
-  @Test
-  public void emptyDaysShouldResultIn400() throws Exception {
-    String payload = paymentRequestWithEmptyDays();
+  @Nested
+  class GetEntrantPayments {
 
-    mockMvc
-        .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON).header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-        .andExpect(status().isBadRequest());
-    verify(initiatePaymentService, never()).createPayment(any());
-  }
+    @Test
+    public void shouldReturn200StatusCodeWhenParamsAreValid() throws Exception {
+      String payload = requestWithVrns(Arrays.asList("CAS123", "CAS124"));
+      mockValidGetPaidEntrantPaymentScenario();
 
-  @Test
-  public void invalidVrnShouldResultIn400() throws Exception {
-    String payload = paymentRequestWithVrn("1234567890123456");
+      performRequestWithContent(payload)
+          .andExpect(status().isOk())
+          .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID));
 
-    mockMvc
-        .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON).header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-        .andExpect(status().isBadRequest());
-    verify(initiatePaymentService, never()).createPayment(any());
-  }
+      verify(getPaidEntrantPaymentsService).getResults(any(), any(), any(), any());
+    }
 
-  @Test
-  public void invalidAmountShouldResultIn400() throws Exception {
-    String payload = paymentRequestWithAmount(-1250);
+    @Test
+    public void shouldReturn400StatusCodeWhenVrnsIsNull() throws Exception {
+      String payload = requestWithVrns(null);
 
-    mockMvc
-        .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON).header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-        .andExpect(status().isBadRequest());
-    verify(initiatePaymentService, never()).createPayment(any());
-  }
+      performRequestWithContent(payload)
+          .andExpect(status().isBadRequest())
+          .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
+          .andExpect(jsonPath("message").value("VRNs cannot be blank."));
 
-  @Test
-  public void invalidReturnUrlShouldResultIn400() throws Exception {
-    String payload = paymentRequestWithEmptyReturnUrl();
+      verify(getPaidEntrantPaymentsService, never()).getResults(any(), any(), any(), any());
+    }
 
-    mockMvc
-        .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON).header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-        .andExpect(status().isBadRequest());
-    verify(initiatePaymentService, never()).createPayment(any());
-  }
+    @Test
+    public void shouldReturn400StatusCodeWhenStartDateIsNull() throws Exception {
+      String payload = requestWithStartDate(null);
 
-  @Test
-  @Disabled // TODO enable once the whole flow with passing tariffCode from UI is completed
-  public void invalidTariffCodeShouldResultIn400() throws Exception {
-    String payload = paymentRequestWithEmptyTariffCode();
+      performRequestWithContent(payload)
+          .andExpect(status().isBadRequest())
+          .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
+          .andExpect(jsonPath("message").value("startDate cannot be null."));
 
-    mockMvc
-        .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON).header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-        .andExpect(status().isBadRequest());
-    verify(initiatePaymentService, never()).createPayment(any());
-  }
+      verify(getPaidEntrantPaymentsService, never()).getResults(any(), any(), any(), any());
+    }
 
-  @Test
-  public void shouldReturnValidResponse() throws Exception {
-    InitiatePaymentRequest requestParams = baseRequestBuilder().build();
-    String payload = toJsonString(requestParams);
-    Payment successfullyCreatedPayment = Payments.existing();
-    given(initiatePaymentService.createPayment(requestParams))
-        .willReturn(successfullyCreatedPayment);
+    @Test
+    public void shouldReturn400StatusCodeWhenEndDateIsNull() throws Exception {
+      String payload = requestWithEndDate(null);
 
-    mockMvc
-        .perform(post(BASE_PATH).content(payload).contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON).header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
-        .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.paymentId").value(successfullyCreatedPayment.getId().toString()))
-        .andExpect(jsonPath("$.nextUrl").value(successfullyCreatedPayment.getNextUrl()));
-    verify(initiatePaymentService).createPayment(requestParams);
-  }
+      performRequestWithContent(payload)
+          .andExpect(status().isBadRequest())
+          .andExpect(header().string(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
+          .andExpect(jsonPath("message").value("endDate cannot be null."));
 
-  private String paymentRequestWithEmptyDays() {
-    List<LocalDate> emptyDays = Collections.emptyList();
-    InitiatePaymentRequest requestParams = baseRequestBuilder().days(emptyDays).build();
-    return toJsonString(requestParams);
-  }
+      verify(getPaidEntrantPaymentsService, never()).getResults(any(), any(), any(), any());
+    }
 
-  private String paymentRequestWithVrn(String vrn) {
-    InitiatePaymentRequest requestParams = baseRequestBuilder().vrn(vrn).build();
-    return toJsonString(requestParams);
-  }
+    @Test
+    public void shouldReturn400StatusCodeWhenCleanAirZoneIsMissing() throws Exception {
+      String payload = requestWithVrns(Arrays.asList("CAS123"));
 
-  private String paymentRequestWithAmount(Integer amount) {
-    InitiatePaymentRequest requestParams = baseRequestBuilder().amount(amount).build();
-    return toJsonString(requestParams);
-  }
+      mockMvc.perform(post(GET_PAID_PATH).content(payload)
+          .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+          .header("x-api-key", UUID.randomUUID()))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("message").value("Missing request header 'X-Correlation-ID'"));
 
-  private String paymentRequestWithEmptyReturnUrl() {
-    InitiatePaymentRequest requestParams = baseRequestBuilder().returnUrl("").build();
-    return toJsonString(requestParams);
-  }
+      verify(getPaidEntrantPaymentsService, never()).getResults(any(), any(), any(), any());
+    }
 
-  private String paymentRequestWithEmptyTariffCode() {
-    InitiatePaymentRequest requestParams = baseRequestBuilder().tariffCode("").build();
-    return toJsonString(requestParams);
+    private ResultActions performRequestWithContent(String payload) throws Exception {
+      return mockMvc.perform(post(GET_PAID_PATH).content(payload)
+          .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .header("x-api-key", UUID.randomUUID())
+          .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON));
+    }
+
+    private String requestWithVrns(List<String> vrns) {
+      PaidPaymentsRequest request = basePaidPaymentsResultBuilder().vrns(vrns).build();
+
+      return toJsonString(request);
+    }
+
+    private String requestWithStartDate(LocalDate startDate) {
+      PaidPaymentsRequest request = basePaidPaymentsResultBuilder().startDate(startDate).build();
+
+      return toJsonString(request);
+    }
+
+    private String requestWithEndDate(LocalDate endDate) {
+      PaidPaymentsRequest request = basePaidPaymentsResultBuilder().endDate(endDate).build();
+
+      return toJsonString(request);
+    }
+
+    private PaidPaymentsRequest.PaidPaymentsRequestBuilder basePaidPaymentsResultBuilder() {
+      return PaidPaymentsRequest.builder()
+          .vrns(Arrays.asList("CAS123", "CAS124"))
+          .startDate(LocalDate.of(2020, 1, 1))
+          .endDate(LocalDate.of(2020, 2, 1));
+    }
+
+    private void mockValidGetPaidEntrantPaymentScenario() {
+      EntrantPayment validEntrantPayment = EntrantPayments
+          .anyPaid()
+          .toBuilder()
+          .travelDate(LocalDate.of(2020, 1, 1))
+          .build();
+
+      Map<String, List<EntrantPayment>> result = ImmutableMap
+          .of("CAS123", Arrays.asList(validEntrantPayment));
+
+      given(getPaidEntrantPaymentsService.getResults(any(), any(), any(), any()))
+          .willReturn(result);
+    }
   }
 
   @SneakyThrows
-  private String toJsonString(InitiatePaymentRequest requestParams) {
-    return objectMapper.writeValueAsString(requestParams);
-  }
-
-  private InitiatePaymentRequest.InitiatePaymentRequestBuilder baseRequestBuilder() {
-    return InitiatePaymentRequest.builder().cleanAirZoneId(UUID.randomUUID()).days(days)
-        .vrn("TEST123").amount(1050).returnUrl("https://example.return.url")
-        .tariffCode("BCC01-private_car");
+  private String toJsonString(Object request) {
+    return objectMapper.writeValueAsString(request);
   }
 }

--- a/src/test/java/uk/gov/caz/psr/repository/EntrantPaymentRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/EntrantPaymentRepositoryTest.java
@@ -191,20 +191,6 @@ class EntrantPaymentRepositoryTest {
       assertThat(throwable).isInstanceOf(IllegalArgumentException.class)
           .hasMessage("VRN cannot be empty");
     }
-//    @Test
-//    public void shouldThrowNIllegalArgumentExceptionWhenVrnIsEmpty() {
-//      // given
-//      String vrn = null;
-//
-//      // when
-//      Throwable throwable = catchThrowable(
-//          () -> cazEntrantPaymentRepository
-//              .findOneByVrnAndCazEntryDate(UUID.randomUUID(), "", LocalDate.now()));
-//
-//      // then
-//      assertThat(throwable).isInstanceOf(IllegalArgumentException.class)
-//          .hasMessage("VRN cannot be empty");
-//    }
 
 //    TODO: Fix with the payment updates CAZ-1716
 //    @Test
@@ -300,6 +286,65 @@ class EntrantPaymentRepositoryTest {
       // then
       assertThat(throwable).isInstanceOf(NullPointerException.class)
           .hasMessage("'paymentId' cannot be null");
+    }
+  }
+
+  @Nested
+  class FindAllPaidByVrnAndDateRangeAndCazId {
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenVrnIsNull() {
+      // given
+      String vrn = null;
+      LocalDate startDate = LocalDate.now();
+      LocalDate endDate = LocalDate.now();
+      UUID cleanAirZoneId = UUID.randomUUID();
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> entrantPaymentRepository.findAllPaidByVrnAndDateRangeAndCazId(
+              vrn, startDate, endDate, cleanAirZoneId));
+
+      // then
+      assertThat(throwable).isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("VRN cannot be empty");
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenDateIsNull() {
+      // given
+      String vrn = "CAS123";
+      LocalDate startDate = null;
+      LocalDate endDate = LocalDate.now();
+      UUID cleanAirZoneId = UUID.randomUUID();
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> entrantPaymentRepository.findAllPaidByVrnAndDateRangeAndCazId(
+              vrn, startDate, endDate, cleanAirZoneId));
+
+      // then
+      assertThat(throwable).isInstanceOf(NullPointerException.class)
+          .hasMessage("startDate cannot be null");
+
+    }
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenCazIdIsNull() {
+      // given
+      String vrn = "CAS123";
+      LocalDate startDate = LocalDate.now();
+      LocalDate endDate = LocalDate.now();
+      UUID cleanAirZoneId = null;
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> entrantPaymentRepository.findAllPaidByVrnAndDateRangeAndCazId(
+              vrn, startDate, endDate, cleanAirZoneId));
+
+      // then
+      assertThat(throwable).isInstanceOf(NullPointerException.class)
+          .hasMessage("cleanAirZoneId cannot be null");
     }
   }
 }

--- a/src/test/java/uk/gov/caz/psr/service/GetPaidEntrantPaymentsServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/GetPaidEntrantPaymentsServiceTest.java
@@ -1,0 +1,89 @@
+package uk.gov.caz.psr.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.caz.psr.model.EntrantPayment;
+import uk.gov.caz.psr.repository.EntrantPaymentRepository;
+import uk.gov.caz.psr.util.TestObjectFactory.EntrantPayments;
+
+@ExtendWith(MockitoExtension.class)
+class GetPaidEntrantPaymentsServiceTest {
+
+  @Mock
+  private EntrantPaymentRepository entrantPaymentRepository;
+
+  @InjectMocks
+  private GetPaidEntrantPaymentsService getPaidEntrantPaymentsService;
+
+  private final static String ANY_VRN_1 = "CAS123";
+  private final static String ANY_VRN_2 = "CAS125";
+  private final static List<String> ANY_VRNS_LIST = Arrays.asList(ANY_VRN_1, ANY_VRN_2);
+  private final static LocalDate ANY_START_DATE = LocalDate.of(2020, 1, 1);
+  private final static LocalDate ANY_END_DATE = LocalDate.of(2020, 2, 1);
+  private final static UUID ANY_UUID = UUID.fromString("6cb5a6b1-18ae-4b06-ac29-f8433099381c");
+
+  @Test
+  public void shouldReturnEmptyCollectionWhenNoDatesArePaid() {
+    // given
+    mockEmptyResultFromEntrantPaymentRepository();
+
+    // when
+    Map<String, List<EntrantPayment>> result = getPaidEntrantPaymentsService
+        .getResults(ANY_VRNS_LIST, ANY_START_DATE, ANY_END_DATE, ANY_UUID);
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnCollectionOfPaidDatesWhenThereArePaidDates() {
+    // given
+    mockNonEmptyResultFromEntrantPaymentRepository();
+
+    // when
+    Map<String, List<EntrantPayment>> result = getPaidEntrantPaymentsService
+        .getResults(ANY_VRNS_LIST, ANY_START_DATE, ANY_END_DATE, ANY_UUID);
+
+    // then
+    assertThat(result).isNotEmpty();
+    assertThat(result.size()).isEqualTo(2);
+  }
+
+  private void mockEmptyResultFromEntrantPaymentRepository() {
+    when(entrantPaymentRepository.findAllPaidByVrnAndDateRangeAndCazId(any(), any(), any(), any()))
+        .thenReturn(new ArrayList<>());
+  }
+
+  private void mockNonEmptyResultFromEntrantPaymentRepository() {
+    when(entrantPaymentRepository.findAllPaidByVrnAndDateRangeAndCazId(any(), any(), any(), any()))
+        .thenReturn(buildMockedEntrantPaymentRepositoryResult());
+  }
+
+  private List<EntrantPayment> buildMockedEntrantPaymentRepositoryResult() {
+    return Arrays.asList(
+        buildEntrantPaymentForVrn(ANY_VRN_1),
+        buildEntrantPaymentForVrn(ANY_VRN_2)
+    );
+  }
+
+  private EntrantPayment buildEntrantPaymentForVrn(String vrn) {
+    return EntrantPayments.anyPaid().toBuilder()
+        .vrn(vrn)
+        .travelDate(LocalDate.of(2020, 1, 15))
+        .cleanAirZoneId(ANY_UUID)
+        .build();
+  }
+}


### PR DESCRIPTION
**Introduced changes**
* `PaymentsController#getPaidEntrantPayment` action
* `GetPaidEntrantPaymentsService`
* `List<EntrantPayment> findAllPaidByVrnAndDateRangeAndCazId` in `EntrantPaymentRepository`
* Copied parameters validation mechanism from Accounts project

* Javadocs, all unit tests and integration tests.

**Additional info**
* [Link to CAZ-1760 JIRA Card](https://eaflood.atlassian.net/browse/CAZ-1760)

**Manual testing**

![Screenshot 2020-01-27 at 16 12 24](https://user-images.githubusercontent.com/4506633/73351626-b608ad80-428f-11ea-88f3-49c7160ec76e.png)
