### PR TITLE
[CAZ-1870] Return 404 for PaymentStatus

### DIFF
--- a/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/GetChargeSettlementPaymentStatusTestIT.java
@@ -36,10 +36,14 @@ import uk.gov.caz.psr.util.TestObjectFactory.PaymentStatusFactory;
 public class GetChargeSettlementPaymentStatusTestIT {
 
   private static final String NOT_PAID_NOT_EXISTING_DATE_STRING = "2019-10-30";
-  private static final String NOT_PAID_EXISTING_DATE_STRING = "2019-11-03";
-  private static final String REFUNDED_DATE_STRING = "2019-11-02";
   private static final String PAID_DATE_STRING = "2019-11-01";
+  private static final String REFUNDED_DATE_STRING = "2019-11-02";
+  private static final String NOT_PAID_EXISTING_DATE_STRING = "2019-11-03";
   private static final String PAID_MULTIPLE_PAYMENTS_DATE_STRING = "2019-11-04";
+  private static final String FAILED_PAYMENT_NOT_EXISTING_DATE_STRING = "2019-11-06";
+  private static final String PAID_IN_LA_BUT_ENTRANT_NOT_REGISTERED_DATE_STRING = "2019-11-07";
+  private static final String REFUNDED_BUT_NOT_CAPTURED_DATE_STRING = "2019-11-08";
+  private static final String PAID_BUT_ENTRANT_NOT_REGISTERED_DATE_STRING = "2019-11-09";
 
   private static final String VALID_CAZ_ID = "b8e53786-c5ca-426a-a701-b14ee74857d4";
   private static final String VALID_CORRELATION_HEADER = "79b7a48f-27c7-4947-bd1c-670f981843ef";
@@ -47,8 +51,8 @@ public class GetChargeSettlementPaymentStatusTestIT {
   private static final String VALID_EXTERNAL_ID_FOR_NOT_PAID = "12345test";
   private static final String VALID_EXTERNAL_ID_FOR_PAID = "54321test";
   private static final String VALID_CASE_REFERENCE = "case-reference123";
-  private static final Long VALID_PAYMENT_REFERENCE = (long) 3001;
-  private static final Long PAYMENT_REFERENCE_UNPAID = (long) 3000;
+  private static final Long VALID_PAYMENT_REFERENCE = 3001L;
+  private static final Long PAYMENT_REFERENCE_UNPAID = 3000L;
   private static final String PAYMENT_STATUS_GET_PATH = ChargeSettlementController.BASE_PATH +
       ChargeSettlementController.PAYMENT_STATUS_PATH;
 
@@ -62,7 +66,7 @@ public class GetChargeSettlementPaymentStatusTestIT {
   private PaymentRepository paymentsRepository;
 
   @Test
-  public void shouldReturn200WithNotPaidStatusWhenDoesNotExistInDatabase() throws Exception {
+  public void shouldReturn404WhenDoesNotExistInDatabase() throws Exception {
     String nonExistingVrn = "CAS222";
 
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
@@ -73,8 +77,7 @@ public class GetChargeSettlementPaymentStatusTestIT {
         .header(Headers.X_API_KEY, VALID_CAZ_ID)
         .param("vrn", nonExistingVrn)
         .param("dateOfCazEntry", NOT_PAID_NOT_EXISTING_DATE_STRING))
-        .andExpect(status().isOk())
-        .andExpect(content().json(getNotPaidResponse()));
+        .andExpect(status().isNotFound());
   }
 
   @ParameterizedTest
@@ -84,8 +87,99 @@ public class GetChargeSettlementPaymentStatusTestIT {
       "ND 84 VSX", "  ND84V S X ", "N D8   4VSX", // with whitespaces
       "N D8  4v SX " // with whitespaces and changed capitalisation
   })
-  public void shouldReturn200AndPaidPaymentStatusWhenThereIsPaidEntrantExists(
+  public void shouldReturn404WhenEntrantNotRecordedAndFailedWasCreated(String vrn)
+      throws Exception {
+
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.TIMESTAMP, LocalDateTime.now())
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", vrn)
+        .param("dateOfCazEntry", FAILED_PAYMENT_NOT_EXISTING_DATE_STRING))
+        .andExpect(status().isNotFound());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ND84VSX", // existing
+      "Nd84vSX", "nD84vsX", // with changed capitalisation
+      "ND 84 VSX", "  ND84V S X ", "N D8   4VSX", // with whitespaces
+      "N D8  4v SX " // with whitespaces and changed capitalisation
+  })
+  public void shouldReturn200AndPaidPaymentStatusWhenMarkedAsPaidByLaButEntrantNotRecorded(
       String vrn)
+      throws Exception {
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.TIMESTAMP, LocalDateTime.now())
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", vrn)
+        .param("dateOfCazEntry", PAID_IN_LA_BUT_ENTRANT_NOT_REGISTERED_DATE_STRING))
+        .andExpect(status().isOk())
+        .andExpect(content().json(
+            getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE,
+                null, 0L)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ND84VSX", // existing
+      "Nd84vSX", "nD84vsX", // with changed capitalisation
+      "ND 84 VSX", "  ND84V S X ", "N D8   4VSX", // with whitespaces
+      "N D8  4v SX " // with whitespaces and changed capitalisation
+  })
+  public void shouldReturn200AndPaidPaymentStatusWhenPaidButEntrantNotRecorded(String vrn)
+      throws Exception {
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.TIMESTAMP, LocalDateTime.now())
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", vrn)
+        .param("dateOfCazEntry", PAID_BUT_ENTRANT_NOT_REGISTERED_DATE_STRING))
+        .andExpect(status().isOk())
+        .andExpect(content().json(
+            getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE,
+                VALID_EXTERNAL_ID_FOR_PAID, VALID_PAYMENT_REFERENCE)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ND84VSX", // existing
+      "Nd84vSX", "nD84vsX", // with changed capitalisation
+      "ND 84 VSX", "  ND84V S X ", "N D8   4VSX", // with whitespaces
+      "N D8  4v SX " // with whitespaces and changed capitalisation
+  })
+  public void shouldReturn200AndRefundedPaymentStatusWhenMarkedAsRefundedByLaButEntrantNotRecorded(
+      String vrn)
+      throws Exception {
+    mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .header(Constants.X_CORRELATION_ID_HEADER, VALID_CORRELATION_HEADER)
+        .header(Headers.TIMESTAMP, LocalDateTime.now())
+        .header(Headers.X_API_KEY, VALID_CAZ_ID)
+        .param("vrn", vrn)
+        .param("dateOfCazEntry", REFUNDED_BUT_NOT_CAPTURED_DATE_STRING))
+        .andExpect(status().isOk())
+        .andExpect(content().json(
+            getResponseWith(InternalPaymentStatus.REFUNDED, VALID_CASE_REFERENCE,
+                null, 0L)));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "ND84VSX", // existing
+      "Nd84vSX", "nD84vsX", // with changed capitalisation
+      "ND 84 VSX", "  ND84V S X ", "N D8   4VSX", // with whitespaces
+      "N D8  4v SX " // with whitespaces and changed capitalisation
+  })
+  public void shouldReturn200AndPaidPaymentStatusWhenPaidEntrantExists(String vrn)
       throws Exception {
     mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
         .contentType(MediaType.APPLICATION_JSON)
@@ -97,7 +191,8 @@ public class GetChargeSettlementPaymentStatusTestIT {
         .param("dateOfCazEntry", PAID_DATE_STRING))
         .andExpect(status().isOk())
         .andExpect(content().json(
-            getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE, VALID_EXTERNAL_ID_FOR_PAID, VALID_PAYMENT_REFERENCE)));
+            getResponseWith(InternalPaymentStatus.PAID, VALID_CASE_REFERENCE,
+                VALID_EXTERNAL_ID_FOR_PAID, VALID_PAYMENT_REFERENCE)));
   }
 
   @ParameterizedTest

--- a/src/it/java/uk/gov/caz/psr/SuccessPaymentStatusUpdateTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/SuccessPaymentStatusUpdateTestIT.java
@@ -81,7 +81,7 @@ public class SuccessPaymentStatusUpdateTestIT {
         .paymentStatusUpdateRequest(paymentStatusUpdateRequest(vrn))
         .whenSubmitted()
         .then()
-        .entrantPaymentsAreUpdatedInTheDatabse();
+        .entrantPaymentsAreUpdatedInTheDatabase();
   }
 
   @Test
@@ -125,6 +125,7 @@ public class SuccessPaymentStatusUpdateTestIT {
     private final ObjectMapper objectMapper;
     private final JdbcTemplate jdbcTemplate;
     private final UUID cleanAirZoneId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
+    private final int EXPECTED_NUMBER_OF_REFUNDED_RECORDS = 4;
 
     private PaymentStatusUpdateRequest paymentStatusUpdateRequest;
 
@@ -169,7 +170,7 @@ public class SuccessPaymentStatusUpdateTestIT {
       return objectMapper.writeValueAsString(request);
     }
 
-    public PaymentStatusUpdateJourneyAssertion entrantPaymentsAreUpdatedInTheDatabse() {
+    public PaymentStatusUpdateJourneyAssertion entrantPaymentsAreUpdatedInTheDatabase() {
       verifyThatRefundedEntrantPaymentsExists();
       return this;
     }
@@ -185,7 +186,7 @@ public class SuccessPaymentStatusUpdateTestIT {
           "clean_air_zone_id = '" + cleanAirZoneId.toString() + "' AND "
               + "vrn = 'ND84VSX' AND "
               + "payment_status = '" + InternalPaymentStatus.REFUNDED.name() + "'");
-      assertThat(vehicleEntrantCount).isEqualTo(3);
+      assertThat(vehicleEntrantCount).isEqualTo(EXPECTED_NUMBER_OF_REFUNDED_RECORDS);
     }
 
     private void verifyThatNewEntrantPaymentWasCreated() {

--- a/src/it/java/uk/gov/caz/psr/repository/PaymentStatusRepositoryTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/repository/PaymentStatusRepositoryTestIT.java
@@ -14,20 +14,64 @@ import uk.gov.caz.psr.annotation.IntegrationTest;
 import uk.gov.caz.psr.model.PaymentStatus;
 
 @IntegrationTest
+@Sql(scripts = "classpath:data/sql/add-payments-for-payment-status.sql",
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = {"classpath:data/sql/clear-all-payments.sql"},
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 class PaymentStatusRepositoryTestIT {
 
   @Autowired
   private PaymentStatusRepository repository;
 
-  @Sql(scripts = "classpath:data/sql/add-payments-for-payment-status.sql",
-      executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-  @Sql(scripts = {"classpath:data/sql/clear-all-payments.sql"},
-      executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
-
   @Test
   public void shouldReturnNonEmptyCollection() {
     // given
-    LocalDate dateOfCazEntry = LocalDate.of(2019, 11, 04);
+    LocalDate dateOfCazEntry = LocalDate.of(2019, 11, 4);
+    String vrn = "ND84VSX";
+    UUID cazId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
+
+    // when
+    Collection<PaymentStatus> results = repository
+        .findByCazIdAndVrnAndEntryDate(cazId, vrn, dateOfCazEntry);
+
+    // then
+    assertThat(results).isNotEmpty();
+  }
+
+  @Test
+  public void shouldReturnEmptyCollectionWhenNotSuccessfullyPaidAndNotEnteredCAZ() {
+    // given
+    LocalDate dateOfCazEntry = LocalDate.of(2019, 11, 6);
+    String vrn = "ND84VSX";
+    UUID cazId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
+
+    // when
+    Collection<PaymentStatus> results = repository
+        .findByCazIdAndVrnAndEntryDate(cazId, vrn, dateOfCazEntry);
+
+    // then
+    assertThat(results).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnNonEmptyCollectionWhenMarkedByLAasPaidButEntrantNotCaptured() {
+    // given
+    LocalDate dateOfCazEntry = LocalDate.of(2019, 11, 7);
+    String vrn = "ND84VSX";
+    UUID cazId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
+
+    // when
+    Collection<PaymentStatus> results = repository
+        .findByCazIdAndVrnAndEntryDate(cazId, vrn, dateOfCazEntry);
+
+    // then
+    assertThat(results).isNotEmpty();
+  }
+
+  @Test
+  public void shouldReturnNonEmptyCollectionWhenRefundedByLaAndEntrantNotCaptured() {
+    // given
+    LocalDate dateOfCazEntry = LocalDate.of(2019, 11, 8);
     String vrn = "ND84VSX";
     UUID cazId = UUID.fromString("b8e53786-c5ca-426a-a701-b14ee74857d4");
 

--- a/src/it/resources/data/sql/add-payments-for-payment-status.sql
+++ b/src/it/resources/data/sql/add-payments-for-payment-status.sql
@@ -4,26 +4,40 @@ INSERT INTO caz_payment.t_payment(
 	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', 'SUCCESS', '12345test', 100, now(), now(), 3000),
 	  ('b73a9b3c-d692-4e7e-b094-1715c5e4a036', 'CREDIT_DEBIT_CARD', 'SUCCESS', '54321test', 200, now(), now(), 3001),
 	  -- Payment which is not finished
-	  ('3e109f68-c11f-48dc-b27a-fa6a6bd387f6', 'CREDIT_DEBIT_CARD', 'STARTED', '12test345', 100, now(), null, 3002);
+	  ('3e109f68-c11f-48dc-b27a-fa6a6bd387f6', 'CREDIT_DEBIT_CARD', 'STARTED', '12test345', 100, now(), null, 3002),
+	  -- Payment which is Failed
+	  ('b17311f7-da17-48c2-9f17-a0df482dfcfc', 'CREDIT_DEBIT_CARD', 'FAILED', '321321test', 300, now(), now(), 3003);
 
 
 INSERT INTO caz_payment.t_clean_air_zone_entrant_payment(
-	clean_air_zone_entrant_payment_id, vrn, clean_air_zone_id, travel_date, charge, tariff_code, payment_status, case_reference, update_actor)
+	clean_air_zone_entrant_payment_id, vrn, clean_air_zone_id, travel_date, charge, tariff_code, payment_status, case_reference, update_actor, vehicle_entrant_captured)
 	VALUES
 	  -- Valid with PAID status
-	  ('43ea77cc-93cb-4df3-b731-5244c0de9cc8', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-01', 50, 'tariffCode!', 'PAID', 'case-reference123', 'USER'),
+	  ('43ea77cc-93cb-4df3-b731-5244c0de9cc8', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-01', 50, 'tariffCode!', 'PAID', 'case-reference123', 'USER', true),
 
     -- Valid with REFUNDED status
-	  ('688f8278-2f0f-4710-bb7c-6b0cca04c1bc', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 50, 'tariffCode!', 'REFUNDED', 'case-reference123', 'LA'),
+	  ('688f8278-2f0f-4710-bb7c-6b0cca04c1bc', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-02', 50, 'tariffCode!', 'REFUNDED', 'case-reference123', 'LA', true),
+
+    -- Valid with REFUNDED status and not recorded by VCCS
+	  ('fd028442-dc28-43df-b40f-6571c4fc0f98', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-08', 50, 'tariffCode!', 'REFUNDED', 'case-reference123', 'LA', false),
 
     -- Valid with NOT_PAID status
-	  ('9e8a8d54-25ff-43e6-85f6-01a4c8f2a2d2', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 50, 'tariffCode!', 'NOT_PAID', 'case-reference123', 'VCCS_API'),
+	  ('9e8a8d54-25ff-43e6-85f6-01a4c8f2a2d2', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-03', 50, 'tariffCode!', 'NOT_PAID', 'case-reference123', 'VCCS_API', true),
 
     -- Multiple payment only latest PAID
-    ('9c3f36fa-0ddd-4204-b106-3fc90af6efb6', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-04', 50, 'tariffCode!', 'PAID', 'case-reference123', 'USER'),
+    ('9c3f36fa-0ddd-4204-b106-3fc90af6efb6', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-04', 50, 'tariffCode!', 'PAID', 'case-reference123', 'USER', true),
 
     -- Valid associated with not finished Payment
-    ('9f6212bc-596f-47ee-a927-928441e405c5', 'CAS123', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-05', 50, 'tariffCode!', 'PAID', 'case-ref-14', 'VCCS_API');
+    ('9f6212bc-596f-47ee-a927-928441e405c5', 'CAS123', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-05', 50, 'tariffCode!', 'PAID', 'case-ref-14', 'VCCS_API', true),
+
+    -- Not finished payment and not entered the CAZ
+    ('ee491b03-5d68-4b6a-a645-e528a68933d9', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-06', 50, 'tariffCode!', 'NOT_PAID', 'case-reference123', 'USER', false),
+
+    -- Finished payment and not entered the CAZ
+    ('88b91c4c-a859-48a4-b179-d23df75a2d92', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-09', 50, 'tariffCode!', 'PAID', 'case-reference123', 'USER', false),
+
+    -- Marked as not paid by LA but not recorded by VCCS
+    ('63461346-df3b-43ea-9718-e79a391d62b9', 'ND84VSX', 'b8e53786-c5ca-426a-a701-b14ee74857d4', '2019-11-07', 50, 'tariffCode!', 'PAID', 'case-reference123', 'LA', false);
 
 INSERT INTO caz_payment.t_clean_air_zone_entrant_payment_match(
 	id, clean_air_zone_entrant_payment_id, payment_id, latest)
@@ -33,4 +47,6 @@ INSERT INTO caz_payment.t_clean_air_zone_entrant_payment_match(
   ('b5d85dbe-3ece-42d5-be81-d57e41471c5f', '9e8a8d54-25ff-43e6-85f6-01a4c8f2a2d2', 'b71b72a5-902f-4a16-a91d-1a4463b801db', true),
   ('27e276bc-aed1-4b4b-904f-5d94548d8dfe', '9c3f36fa-0ddd-4204-b106-3fc90af6efb6', 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', true),
   ('512b0982-3e7e-4be6-b0ef-2b3310627a0a', '9c3f36fa-0ddd-4204-b106-3fc90af6efb6', 'b71b72a5-902f-4a16-a91d-1a4463b801db', false),
-  ('279c55ba-6bf6-444e-afe7-c328d2820a3f', '9f6212bc-596f-47ee-a927-928441e405c5', '3e109f68-c11f-48dc-b27a-fa6a6bd387f6', true);
+  ('279c55ba-6bf6-444e-afe7-c328d2820a3f', '9f6212bc-596f-47ee-a927-928441e405c5', '3e109f68-c11f-48dc-b27a-fa6a6bd387f6', true),
+  ('46fda8a5-230d-4ff7-a74d-cf063f66cacf', '88b91c4c-a859-48a4-b179-d23df75a2d92', 'b73a9b3c-d692-4e7e-b094-1715c5e4a036', true),
+  ('7905c9d9-df42-4795-8ef9-8d7cd4c6fce7', 'ee491b03-5d68-4b6a-a645-e528a68933d9', 'b17311f7-da17-48c2-9f17-a0df482dfcfc', true);

--- a/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
+++ b/src/main/java/uk/gov/caz/psr/controller/ChargeSettlementController.java
@@ -5,6 +5,7 @@ import static uk.gov.caz.psr.util.AttributesNormaliser.normalizeVrn;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,13 +70,15 @@ public class ChargeSettlementController implements ChargeSettlementControllerApi
           "getPaymentStatus.validationErrorTitle", bindingResult);
     }
 
-    PaymentStatus paymentStatus = chargeSettlementService
+    Optional<PaymentStatus> paymentStatus = chargeSettlementService
         .findChargeSettlement(
             cleanAirZoneId,
             normalizeVrn(request.getVrn()),
             LocalDate.parse(request.getDateOfCazEntry()));
 
-    return ResponseEntity.ok(PaymentStatusResponse.from(paymentStatus));
+    return paymentStatus.map(PaymentStatusResponse::from)
+        .map(ResponseEntity::ok)
+        .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   @Override

--- a/src/main/java/uk/gov/caz/psr/repository/PaymentStatusRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/PaymentStatusRepository.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
+import uk.gov.caz.psr.model.EntrantPaymentUpdateActor;
 import uk.gov.caz.psr.model.InternalPaymentStatus;
 import uk.gov.caz.psr.model.PaymentStatus;
 
@@ -28,15 +29,19 @@ public class PaymentStatusRepository {
       + "payment.payment_provider_id, "
       + "payment.central_reference_number "
       + "FROM caz_payment.t_clean_air_zone_entrant_payment entrant_payment "
-      + "INNER JOIN caz_payment.t_clean_air_zone_entrant_payment_match entrant_payment_match "
+      + "LEFT OUTER JOIN caz_payment.t_clean_air_zone_entrant_payment_match entrant_payment_match "
       + "ON entrant_payment.clean_air_zone_entrant_payment_id = "
       + "entrant_payment_match.clean_air_zone_entrant_payment_id "
       + "AND entrant_payment_match.latest = true "
-      + "INNER JOIN caz_payment.t_payment payment "
+      + "LEFT OUTER JOIN caz_payment.t_payment payment "
       + "ON entrant_payment_match.payment_id = payment.payment_id "
       + "WHERE entrant_payment.clean_air_zone_id = ? AND "
       + "entrant_payment.vrn = ? AND "
-      + "entrant_payment.travel_date = ?";
+      + "entrant_payment.travel_date = ? AND "
+      // exclude not captured with failed payment records.
+      + "(entrant_payment.vehicle_entrant_captured is true OR "
+      + "entrant_payment.update_actor != '" + EntrantPaymentUpdateActor.USER.name() + "' OR "
+      + "entrant_payment.payment_status != 'NOT_PAID')";
 
   /**
    * Finds collection of matching records in join table. To represent the found records

--- a/src/main/java/uk/gov/caz/psr/service/ChargeSettlementService.java
+++ b/src/main/java/uk/gov/caz/psr/service/ChargeSettlementService.java
@@ -1,8 +1,8 @@
 package uk.gov.caz.psr.service;
 
-import com.google.common.collect.Iterables;
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,12 +28,12 @@ public class ChargeSettlementService {
    * @return {@link PaymentStatus}
    * @throws IllegalStateException when single day was paid twice
    */
-  public PaymentStatus findChargeSettlement(UUID cazId, String vrn,
+  public Optional<PaymentStatus> findChargeSettlement(UUID cazId, String vrn,
       LocalDate dateOfCazEntry) {
 
     Collection<PaymentStatus> paymentStatuses = paymentStatusRepository
         .findByCazIdAndVrnAndEntryDate(cazId, vrn, dateOfCazEntry);
 
-    return Iterables.getFirst(paymentStatuses, PaymentStatus.getEmptyPaymentStatusResponse());
+    return paymentStatuses.stream().findFirst();
   }
 }

--- a/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.SneakyThrows;
 import org.hamcrest.core.IsNull;
@@ -388,7 +389,7 @@ class ChargeSettlementControllerTest {
           .anyWithStatus(InternalPaymentStatus.PAID);
 
       given(chargeSettlementService.findChargeSettlement(any(), any(), any()))
-          .willReturn(paymentStatusStub);
+          .willReturn(Optional.of(paymentStatusStub));
 
       mockMvc.perform(get(PAYMENT_STATUS_GET_PATH)
           .header(Headers.TIMESTAMP, ANY_TIMESTAMP)

--- a/src/test/java/uk/gov/caz/psr/service/ChargeSettlementServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/ChargeSettlementServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,16 +33,16 @@ class ChargeSettlementServiceTest {
   private ChargeSettlementService chargeSettlementService;
 
   @Test
-  void shouldReturnNotPaidWhenRepositoryReturnsEmptyCollection() {
+  void shouldReturnEmptyElementWhenRepositoryReturnsEmptyCollection() {
     //given
     mockEmptyCollection();
 
     //when
-    PaymentStatus paymentStatus = chargeSettlementService
+    Optional<PaymentStatus> paymentStatus = chargeSettlementService
         .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
 
     //then
-    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.NOT_PAID);
+    assertThat(paymentStatus).isEqualTo(Optional.empty());
   }
 
   @Test
@@ -50,11 +51,11 @@ class ChargeSettlementServiceTest {
     mockSingleEntrantPaymentForStatus(InternalPaymentStatus.PAID);
 
     // when
-    PaymentStatus paymentStatus = chargeSettlementService
+    Optional<PaymentStatus> paymentStatus = chargeSettlementService
         .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
 
     // then
-    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.PAID);
+    assertThat(paymentStatus).map(PaymentStatus::getStatus).contains(InternalPaymentStatus.PAID);
   }
 
   @Test
@@ -63,10 +64,11 @@ class ChargeSettlementServiceTest {
     mockSingleEntrantPaymentForStatus(InternalPaymentStatus.NOT_PAID);
 
     //when
-    PaymentStatus paymentStatus = chargeSettlementService
+    Optional<PaymentStatus> paymentStatus = chargeSettlementService
         .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
 
-    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.NOT_PAID);
+    assertThat(paymentStatus).map(PaymentStatus::getStatus)
+        .contains(InternalPaymentStatus.NOT_PAID);
   }
 
   @Test
@@ -75,10 +77,11 @@ class ChargeSettlementServiceTest {
     mockSingleEntrantPaymentForStatus(InternalPaymentStatus.REFUNDED);
 
     //when
-    PaymentStatus paymentStatus = chargeSettlementService
+    Optional<PaymentStatus> paymentStatus = chargeSettlementService
         .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
 
-    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.REFUNDED);
+    assertThat(paymentStatus).map(PaymentStatus::getStatus)
+        .contains(InternalPaymentStatus.REFUNDED);
   }
 
   @Test
@@ -87,10 +90,11 @@ class ChargeSettlementServiceTest {
     mockSingleEntrantPaymentForStatus(InternalPaymentStatus.CHARGEBACK);
 
     //when
-    PaymentStatus paymentStatus = chargeSettlementService
+    Optional<PaymentStatus> paymentStatus = chargeSettlementService
         .findChargeSettlement(ANY_CAZ_ID, ANY_VRN, ANY_DATE);
-
-    assertThat(paymentStatus.getStatus()).isEqualTo(InternalPaymentStatus.CHARGEBACK);
+    
+    assertThat(paymentStatus).map(PaymentStatus::getStatus)
+        .contains(InternalPaymentStatus.CHARGEBACK);
   }
 
   private void mockEmptyCollection() {


### PR DESCRIPTION
Jira card: https://eaflood.atlassian.net/browse/CAZ-1870

Updated the process to return 404 when EntrantPayment not found. 
Added case to return 404 when EntrantPayment not captured in VCCS and failed payment has been processed. 
Added new test cases. 