### PR TITLE
[CAZ-1900] Disallowed to use notPaid paymentStatus in update

### DIFF
--- a/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateDetails.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateDetails.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Value;
+import uk.gov.caz.psr.dto.validation.constraint.ValueIn;
 
 /**
  * A value object which is used as a request for updating payment status which contains payment
@@ -22,10 +23,17 @@ public class PaymentStatusUpdateDetails {
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.payment-status}")
   @NotNull
-  ChargeSettlementPaymentStatus paymentStatus;
+  @ValueIn(possibleValues = {"paid", "refunded", "chargeback"},
+      message = "Incorrect payment status update, please use "
+          + "\"paid\", \"chargeback\", or \"refunded\" instead")
+  String paymentStatus;
 
   @ApiModelProperty(value = "${swagger.model.descriptions.payment-status-update.case-reference}")
   @NotBlank
   @Size(min = 1, max = 15)
   String caseReference;
+
+  public ChargeSettlementPaymentStatus getChargeSettlementPaymentStatus() {
+    return ChargeSettlementPaymentStatus.valueOf(paymentStatus.toUpperCase());
+  }
 }

--- a/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateRequest.java
+++ b/src/main/java/uk/gov/caz/psr/dto/PaymentStatusUpdateRequest.java
@@ -54,7 +54,7 @@ public class PaymentStatusUpdateRequest {
         .vrn(normalizeVrn(vrn))
         .dateOfCazEntry(paymentStatusUpdateDetail.getDateOfCazEntry())
         .paymentStatus(InternalPaymentStatus
-            .valueOf(paymentStatusUpdateDetail.getPaymentStatus().name()))
+            .valueOf(paymentStatusUpdateDetail.getChargeSettlementPaymentStatus().name()))
         .caseReference(paymentStatusUpdateDetail.getCaseReference())
         .build();
   }

--- a/src/main/java/uk/gov/caz/psr/dto/validation/constraint/ValueIn.java
+++ b/src/main/java/uk/gov/caz/psr/dto/validation/constraint/ValueIn.java
@@ -1,0 +1,41 @@
+package uk.gov.caz.psr.dto.validation.constraint;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Constraint annotation for checking whether the value from the request has value from provided
+ * array using {@code ValueInValidator}.
+ */
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = ValueInValidator.class)
+@Documented
+public @interface ValueIn {
+
+  /**
+   * All possible values of Enum.
+   */
+  String[] possibleValues();
+
+  /**
+   * A message that will be returned when validation fails.
+   */
+  String message() default "Value is not valid";
+
+  /**
+   * Unused, but the presence is required by the framework.
+   */
+  Class<?>[] groups() default {};
+
+  /**
+   * Unused, but the presence is required by the framework.
+   */
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/uk/gov/caz/psr/dto/validation/constraint/ValueInValidator.java
+++ b/src/main/java/uk/gov/caz/psr/dto/validation/constraint/ValueInValidator.java
@@ -1,0 +1,34 @@
+package uk.gov.caz.psr.dto.validation.constraint;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Arrays;
+import java.util.Set;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Validator that checks whether the passed argument has the value from
+ * provided valid values array.
+ */
+public class ValueInValidator implements
+    ConstraintValidator<ValueIn, String> {
+
+  private Set<String> validValues;
+
+  public void initialize(ValueIn constraint) {
+    validValues = Arrays.stream(constraint.possibleValues()).collect(toSet());
+  }
+
+  /**
+   * Checks if the passed {@code input} contains at least on non-null parameter.
+   *
+   * @param input   An input request which will be validated.
+   * @param context Validator context (unused).
+   * @return true if {@code input} contains at least on non-null parameter, false otherwise.
+   */
+  @Override
+  public boolean isValid(String input, ConstraintValidatorContext context) {
+    return validValues.contains(input);
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/ChargeSettlementControllerTest.java
@@ -603,8 +603,8 @@ class ChargeSettlementControllerTest {
 
     private List<PaymentStatusUpdateDetails> buildPaymentStatusUpdateDetails() {
       return Arrays.asList(
-          PaymentStatusUpdateDetailsFactory.anyWithStatus(ChargeSettlementPaymentStatus.CHARGEBACK),
-          PaymentStatusUpdateDetailsFactory.anyWithStatus(ChargeSettlementPaymentStatus.REFUNDED));
+          PaymentStatusUpdateDetailsFactory.anyWithStatus("chargeback"),
+          PaymentStatusUpdateDetailsFactory.anyWithStatus("refunded"));
     }
 
     private String requestWithVrn(String vrn) {

--- a/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
+++ b/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
@@ -233,7 +233,7 @@ public class TestObjectFactory {
 
   public static class PaymentStatusUpdateDetailsFactory {
 
-    public static PaymentStatusUpdateDetails anyWithStatus(ChargeSettlementPaymentStatus status) {
+    public static PaymentStatusUpdateDetails anyWithStatus(String status) {
       return PaymentStatusUpdateDetails.builder()
           .caseReference("CaseReference")
           .paymentStatus(status)
@@ -243,20 +243,20 @@ public class TestObjectFactory {
 
     public static PaymentStatusUpdateDetails refundedWithDateOfCazEntry(LocalDate date) {
       return PaymentStatusUpdateDetails.builder().caseReference("CaseReference")
-          .paymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
+          .paymentStatus("refunded")
           .dateOfCazEntry(date).build();
     }
 
     public static PaymentStatusUpdateDetails anyInvalid() {
       return PaymentStatusUpdateDetails.builder()
-          .paymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
+          .paymentStatus("refunded")
           .dateOfCazEntry(LocalDate.now())
           .build();
     }
 
     public static PaymentStatusUpdateDetails withCaseReference(String caseReference) {
       return PaymentStatusUpdateDetails.builder()
-          .paymentStatus(ChargeSettlementPaymentStatus.REFUNDED)
+          .paymentStatus("refunded")
           .caseReference(caseReference)
           .dateOfCazEntry(LocalDate.now())
           .build();


### PR DESCRIPTION
Jira card: https://eaflood.atlassian.net/browse/CAZ-1900

Added validation to DTO 
- it validates if the provided value is in specified possible values. 
- updated the type to String to avoid exception on request params mapping when enum value is not exactly the same as defined. 