### PR TITLE
Permit payments to proceed in the event of one being in-flight

### DIFF
--- a/src/main/java/uk/gov/caz/psr/service/InitiateEntrantPaymentsService.java
+++ b/src/main/java/uk/gov/caz/psr/service/InitiateEntrantPaymentsService.java
@@ -124,10 +124,10 @@ public class InitiateEntrantPaymentsService {
         .map(Payment::getExternalPaymentStatus)
         .orElse(null);
 
-    if (relatedPaymentStatus != null && (relatedPaymentStatus.isNotFinished()
-        || relatedPaymentStatus == ExternalPaymentStatus.SUCCESS)) {
-      throw new IllegalStateException("The corresponding payment has been completed or not "
-          + "finished yet, its state is equal to " + relatedPaymentStatus);
+    if (relatedPaymentStatus != null && relatedPaymentStatus == ExternalPaymentStatus.SUCCESS) {
+      throw new IllegalStateException(
+          "The corresponding payment has already been paid with its state equal to "
+              + relatedPaymentStatus);
     }
   }
 

--- a/src/test/java/uk/gov/caz/psr/service/InitiateEntrantPaymentsServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/InitiateEntrantPaymentsServiceTest.java
@@ -262,7 +262,7 @@ class InitiateEntrantPaymentsServiceTest {
 
           // then
           assertThat(throwable).isInstanceOf(IllegalStateException.class)
-              .hasMessageStartingWith("The corresponding payment has been completed or not finished");
+              .hasMessageStartingWith("The corresponding payment has already been paid with its state equal to");
           verify(entrantPaymentRepository, never()).insert(any(EntrantPayment.class));
           verify(entrantPaymentMatchRepository, never())
               .updateLatestToFalseFor(existingEntrantPaymentId);
@@ -289,47 +289,6 @@ class InitiateEntrantPaymentsServiceTest {
               .build();
         });
       }
-
-      @Nested
-      class WhenRelatedPaymentHasNotCompletedExternally {
-
-        @Test
-        public void shouldThrowIllegalStateException() {
-          // given
-          LocalDate notMatchingDate = LocalDate.now();
-          LocalDate matchingDate = LocalDate.now().minusDays(1);
-          List<SingleEntrantPayment> transactions = Arrays.asList(SingleEntrantPayment.builder()
-                  .charge(ANY_CHARGE)
-                  .travelDate(matchingDate)
-                  .vrn(ANY_VRN)
-                  .tariffCode(ANY_TARIFF_CODE)
-                  .build(),
-              SingleEntrantPayment.builder()
-                  .charge(ANY_CHARGE)
-                  .travelDate(notMatchingDate)
-                  .vrn(ANY_VRN)
-                  .tariffCode(ANY_TARIFF_CODE)
-                  .build()
-          );
-          List<LocalDate> travelDates = Arrays.asList(matchingDate, notMatchingDate);
-          UUID existingEntrantPaymentId = UUID.fromString("d34f9d3a-54c7-40e3-9611-60caa783a8b7");
-          mockExistingEntrantPayments(matchingDate, travelDates, existingEntrantPaymentId);
-          mockPaymentRepositoriesWithNotFinishedPayment(existingEntrantPaymentId);
-
-        // when
-        Throwable throwable = catchThrowable(() -> service.processEntrantPaymentsForPayment(
-            ANY_PAYMENT_ID, ANY_CLEAN_AIR_ZONE_ID, transactions));
-
-          // then
-          assertThat(throwable).isInstanceOf(IllegalStateException.class)
-              .hasMessageStartingWith("The corresponding payment has been completed or not finished");
-          verify(entrantPaymentRepository, never()).insert(any(EntrantPayment.class));
-          verify(entrantPaymentMatchRepository, never())
-              .updateLatestToFalseFor(existingEntrantPaymentId);
-          verify(entrantPaymentRepository, never()).update(any(EntrantPayment.class));
-          verify(entrantPaymentMatchRepository, never()).insert(any());
-        }
-      }
     }
   }
 
@@ -337,12 +296,6 @@ class InitiateEntrantPaymentsServiceTest {
     Payment existingPayment = createPayment(ExternalPaymentStatus.INITIATED).build();
     when(paymentRepository.findByEntrantPayment(existingEntrantPaymentId))
         .thenReturn(Optional.of(existingPayment));
-  }
-
-  private void mockPaymentRepositoriesWithNotFinishedPayment(UUID existingEntrantPaymentId) {
-    Payment existingPayment = createPayment(ExternalPaymentStatus.INITIATED).build();
-    mockPaymentRepositoryWithNotFinishedPayment(existingEntrantPaymentId);
-    when(cleanupDanglingPaymentService.processDanglingPayment(any())).thenReturn(existingPayment);
   }
 
   private void mockPaymentRepositoryWithFinishedPayment(UUID existingEntrantPaymentId) {


### PR DESCRIPTION
Permit payments to proceed in the event of one being in-flight. 

Inspecting logs this results in:

10/03/2020 19:50:59.302  INFO test 7117 --- [nio-8080-exec-3] u.g.c.p.s.CleanupDanglingPaymentService  : Updating status of payment '5bdf0e5a-6308-11ea-ac89-7fb4a9ffe604' from 'CREATED' to 'STARTED'
10/03/2020 19:50:59.358  INFO test 7117 --- [nio-8080-exec-3] u.g.c.p.s.CleanupDanglingPaymentService  : Processing the dangling payment '5bdf0e5a-6308-11ea-ac89-7fb4a9ffe604' took 535ms

Practically, and as tested locally, this permits a payment to proceed. In the event of later abandonment, this should get picked up by the dangling payments lambda function (as it will later transition to expired/abdandoned)