### PR TITLE
Revert "Permit payments to proceed in the event of one being in-flight"

### DIFF
--- a/src/main/java/uk/gov/caz/psr/service/InitiateEntrantPaymentsService.java
+++ b/src/main/java/uk/gov/caz/psr/service/InitiateEntrantPaymentsService.java
@@ -124,10 +124,10 @@ public class InitiateEntrantPaymentsService {
         .map(Payment::getExternalPaymentStatus)
         .orElse(null);
 
-    if (relatedPaymentStatus != null && relatedPaymentStatus == ExternalPaymentStatus.SUCCESS) {
-      throw new IllegalStateException(
-          "The corresponding payment has already been paid with its state equal to "
-              + relatedPaymentStatus);
+    if (relatedPaymentStatus != null && (relatedPaymentStatus.isNotFinished()
+        || relatedPaymentStatus == ExternalPaymentStatus.SUCCESS)) {
+      throw new IllegalStateException("The corresponding payment has been completed or not "
+          + "finished yet, its state is equal to " + relatedPaymentStatus);
     }
   }
 


### PR DESCRIPTION
Reverts InformedSolutions/JAQU-CAZ-Payments-API#185 to allow assessment on dangling payment behaviour.