### PR TITLE
NON-JIRA Set `Propagation.REQUIRES_NEW` transaction propagation level…

### DIFF
--- a/src/main/java/uk/gov/caz/psr/service/CleanupDanglingPaymentService.java
+++ b/src/main/java/uk/gov/caz/psr/service/CleanupDanglingPaymentService.java
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.caz.psr.dto.external.GetPaymentResult;
 import uk.gov.caz.psr.model.ExternalPaymentDetails;
 import uk.gov.caz.psr.model.ExternalPaymentStatus;
@@ -35,6 +37,7 @@ public class CleanupDanglingPaymentService {
    * @return Processed {@code danglingPayment} with the new, updated external status (if different
    *     than the current one) and loaded associated {@link uk.gov.caz.psr.model.EntrantPayment}s.
    */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public Payment processDanglingPayment(Payment danglingPayment) {
     checkPreconditions(danglingPayment);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     username: postgres
     password: postgres
     hikari:
-      maximum-pool-size: 1
+      maximum-pool-size: 2
   profiles:
     active: dev
 


### PR DESCRIPTION
… for `CleanupDanglingPaymentService#processDanglingPayment` method

This is to handle the case when a duplicated payment is found and an exception is thrown. We need to ensure that changes done by that method are persisted hence they need to be done in a separate transaction.