### PR TITLE
[CAZ-2251] Fix missing MandateId and wrong payment method

### DIFF
--- a/src/it/java/uk/gov/caz/psr/SuccessAddingVehicleEntrantIT.java
+++ b/src/it/java/uk/gov/caz/psr/SuccessAddingVehicleEntrantIT.java
@@ -40,7 +40,8 @@ import uk.gov.caz.psr.dto.VehicleEntrantDto;
 import uk.gov.caz.psr.util.AuditTableWrapper;
 
 @FullyRunningServerIntegrationTest
-@Sql(scripts = "classpath:data/sql/add-entrant-payments.sql",
+@Sql(scripts = {"classpath:data/sql/clear-all-payments.sql",
+    "classpath:data/sql/add-entrant-payments.sql"},
     executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(scripts = {"classpath:data/sql/clear-all-payments.sql",
     "classpath:data/sql/clear-all-caz-entrant-payments.sql"},

--- a/src/main/java/uk/gov/caz/psr/controller/DirectDebitPaymentsController.java
+++ b/src/main/java/uk/gov/caz/psr/controller/DirectDebitPaymentsController.java
@@ -27,8 +27,7 @@ public class DirectDebitPaymentsController implements DirectDebitPaymentsControl
     request.validate();
     Payment payment = createDirectDebitPaymentService.createPayment(
         DirectDebitPaymentRequestToModelConverter.toPayment(request),
-        PaymentTransactionsToEntrantsConverter.toSingleEntrantPayments(request.getTransactions()),
-        request.getMandateId()
+        PaymentTransactionsToEntrantsConverter.toSingleEntrantPayments(request.getTransactions())
     );
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(CreateDirectDebitPaymentResponse.from(payment));

--- a/src/main/java/uk/gov/caz/psr/dto/ChargeSettlementPaymentMethod.java
+++ b/src/main/java/uk/gov/caz/psr/dto/ChargeSettlementPaymentMethod.java
@@ -6,16 +6,21 @@ import uk.gov.caz.psr.model.PaymentMethod;
  * A method of payment in GOV UK Pay service.
  */
 public enum ChargeSettlementPaymentMethod {
-  CREDIT_DEBIT_CARD,
+  CARD,
   DIRECT_DEBIT;
 
   /**
-   * Maps {@link PaymentMethod} to {@link ChargeSettlementPaymentMethod}. If {@code paymentMethod}
-   * is {@code null}, {@code null} is returned.
+   * Maps {CreateDirectDebitPaymentServiceTest@link PaymentMethod} to {@link
+   * ChargeSettlementPaymentMethod}. If {@code paymentMethod} is {@code null}, {@code null} is
+   * returned.
    */
   public static ChargeSettlementPaymentMethod from(PaymentMethod paymentMethod) {
-    return paymentMethod == null
-        ? null
-        : ChargeSettlementPaymentMethod.valueOf(paymentMethod.name());
+    if (paymentMethod == null) {
+      return null;
+    } else if (paymentMethod.equals(PaymentMethod.CREDIT_DEBIT_CARD)) {
+      return ChargeSettlementPaymentMethod.CARD;
+    } else {
+      return ChargeSettlementPaymentMethod.DIRECT_DEBIT;
+    }
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/CreateDirectDebitPaymentService.java
+++ b/src/main/java/uk/gov/caz/psr/service/CreateDirectDebitPaymentService.java
@@ -29,14 +29,13 @@ public class CreateDirectDebitPaymentService {
    * Creates Payment in Payment Provider, inserts Payment details into database.
    */
   @Transactional
-  public Payment createPayment(Payment payment, List<SingleEntrantPayment> entrantPayments,
-      String mandateId) {
+  public Payment createPayment(Payment payment, List<SingleEntrantPayment> entrantPayments) {
     try {
       log.info("Create DirectPayment process: start");
       Payment paymentWithInternalId = initializePaymentWithEntrants(payment, entrantPayments);
 
       DirectDebitPayment directDebitPayment = externalDirectDebitRepository
-          .collectPayment(mandateId,
+          .collectPayment(paymentWithInternalId.getPaymentProviderMandateId(),
               paymentWithInternalId.getTotalPaid(),
               paymentWithInternalId.getReferenceNumber().toString(),
               payment.getCleanAirZoneId());

--- a/src/main/java/uk/gov/caz/psr/util/DirectDebitPaymentRequestToModelConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/DirectDebitPaymentRequestToModelConverter.java
@@ -32,6 +32,7 @@ public class DirectDebitPaymentRequestToModelConverter {
         .userId(StringUtils.hasText(request.getUserId())
             ? UUID.fromString(request.getUserId())
             : null)
+        .paymentProviderMandateId(request.getMandateId())
         .build();
   }
 

--- a/src/test/java/uk/gov/caz/psr/controller/DirectDebitPaymentsControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/DirectDebitPaymentsControllerTest.java
@@ -76,8 +76,7 @@ public class DirectDebitPaymentsControllerTest {
               .accept(MediaType.APPLICATION_JSON))
           .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message")
           .value("Missing request header 'X-Correlation-ID'"));
-      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-          any());
+      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
     }
 
     @Test
@@ -91,8 +90,7 @@ public class DirectDebitPaymentsControllerTest {
               .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
           .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message")
           .value("'transactions' cannot be null or empty"));
-      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-          any());
+      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
     }
 
     @ParameterizedTest
@@ -106,8 +104,7 @@ public class DirectDebitPaymentsControllerTest {
               .accept(MediaType.APPLICATION_JSON)
               .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
           .andExpect(status().isBadRequest());
-      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-          any());
+      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
     }
 
     @Test
@@ -121,8 +118,7 @@ public class DirectDebitPaymentsControllerTest {
               .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
           .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message")
           .value("'charge' in all transactions must be positive"));
-      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-          any());
+      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
     }
 
     @Test
@@ -136,8 +132,7 @@ public class DirectDebitPaymentsControllerTest {
               .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
           .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message")
           .value("Request cannot have duplicated travel date(s)"));
-      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-          any());
+      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
     }
 
     @Test
@@ -152,8 +147,7 @@ public class DirectDebitPaymentsControllerTest {
           .andExpect(status().isBadRequest()).andExpect(jsonPath("$.message")
           .value("'mandateId' cannot be null or empty"));
 
-      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-          any());
+      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
     }
 
     @Test
@@ -168,8 +162,7 @@ public class DirectDebitPaymentsControllerTest {
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.message").value(
               "'tariffCode' in all transactions cannot be null or empty"));
-      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-          any());
+      verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
     }
 
     @Nested
@@ -188,8 +181,7 @@ public class DirectDebitPaymentsControllerTest {
                 .header(X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID))
             .andExpect(status().isBadRequest()).andExpect(
             jsonPath("$.message").value("'userId' must be a valid UUID"));
-        verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList(),
-            any());
+        verify(createDirectDebitPaymentService, never()).createPayment(any(), anyList());
       }
     }
 
@@ -224,8 +216,7 @@ public class DirectDebitPaymentsControllerTest {
       verify(createDirectDebitPaymentService).createPayment(
           DirectDebitPaymentRequestToModelConverter.toPayment(requestParams),
           PaymentTransactionsToEntrantsConverter.toSingleEntrantPayments(
-              requestParams.getTransactions()),
-          requestParams.getMandateId());
+              requestParams.getTransactions()));
     }
 
     private String paymentRequestWithEmptyTransactions() {
@@ -288,8 +279,7 @@ public class DirectDebitPaymentsControllerTest {
       given(createDirectDebitPaymentService.createPayment(
           DirectDebitPaymentRequestToModelConverter.toPayment(requestParams),
           PaymentTransactionsToEntrantsConverter.toSingleEntrantPayments(
-              requestParams.getTransactions()),
-          requestParams.getMandateId())).willReturn(successfullyCreatedPayment);
+              requestParams.getTransactions()))).willReturn(successfullyCreatedPayment);
     }
 
     @SneakyThrows

--- a/src/test/java/uk/gov/caz/psr/service/CreateDirectDebitPaymentServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/CreateDirectDebitPaymentServiceTest.java
@@ -53,8 +53,7 @@ class CreateDirectDebitPaymentServiceTest {
     // when
     Throwable throwable = catchThrowable(() -> createDirectDebitPaymentService.createPayment(
         DirectDebitPaymentRequestToModelConverter.toPayment(request),
-        PaymentTransactionsToEntrantsConverter.toSingleEntrantPayments(request.getTransactions()),
-        request.getMandateId()
+        PaymentTransactionsToEntrantsConverter.toSingleEntrantPayments(request.getTransactions())
     ));
 
     // then

--- a/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
+++ b/src/test/java/uk/gov/caz/psr/util/TestObjectFactory.java
@@ -170,6 +170,7 @@ public class TestObjectFactory {
       return createPaymentWith(entrantPayments, null, null, request.getCleanAirZoneId())
           .toBuilder()
           .paymentMethod(PaymentMethod.DIRECT_DEBIT)
+          .paymentProviderMandateId("exampleMandateId")
           .totalPaid(request.getTransactions().stream().mapToInt(Transaction::getCharge).sum())
           .build();
     }


### PR DESCRIPTION
Fixed 2 bugs: 
1. Wrong payment method in charge settlement API
2. Missing MandateId in payment after DirectDebit Payment. 