### PR TITLE
Expose dd creation date

### DIFF
--- a/src/it/resources/data/json/response/direct-debit-mandates-for-caz-response.json
+++ b/src/it/resources/data/json/response/direct-debit-mandates-for-caz-response.json
@@ -2,15 +2,18 @@
   "mandates": [
     {
       "id": "i4nuo03jginfke5c3ebrvgig6a",
-      "status": "CREATED"
+      "status": "CREATED",
+      "created": "2020-03-19"
     },
     {
       "id": "k4nuo03jginfke5c3ebrvgig6a",
-      "status": "CREATED"
+      "status": "CREATED",
+      "created": "2020-03-19"
     },
     {
       "id": "j4nuo03jginfke5c3ebrvgig6a",
-      "status": "FAILED"
+      "status": "FAILED",
+      "created": null
     }
   ]
 }

--- a/src/it/resources/data/json/response/direct-debit-mandates-response.json
+++ b/src/it/resources/data/json/response/direct-debit-mandates-response.json
@@ -6,15 +6,18 @@
       "mandates": [
         {
           "id": "i4nuo03jginfke5c3ebrvgig6a",
-          "status": "CREATED"
+          "status": "CREATED",
+          "created": null
         },
         {
           "id": "k4nuo03jginfke5c3ebrvgig6a",
-          "status": "CREATED"
+          "status": "CREATED",
+          "created": null
         },
         {
           "id": "j4nuo03jginfke5c3ebrvgig6a",
-          "status": "FAILED"
+          "status": "FAILED",
+          "created": null
         }
       ]
     },

--- a/src/main/java/uk/gov/caz/psr/dto/AccountDirectDebitMandatesResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/AccountDirectDebitMandatesResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.caz.psr.dto;
 
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -30,6 +31,8 @@ public class AccountDirectDebitMandatesResponse {
 
     DirectDebitMandateStatus status;
 
+    Date created;
+    
     public enum DirectDebitMandateStatus {
       CREATED,
       STARTED,

--- a/src/main/java/uk/gov/caz/psr/dto/directdebit/DirectDebitMandatesResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/directdebit/DirectDebitMandatesResponse.java
@@ -1,7 +1,10 @@
 package uk.gov.caz.psr.dto.directdebit;
 
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import lombok.Builder;
 import lombok.Value;
 
@@ -29,6 +32,9 @@ public class DirectDebitMandatesResponse {
 
       String id;
       String status;
+      
+      @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+      Date created;
     }
   }
 }

--- a/src/main/java/uk/gov/caz/psr/dto/directdebit/DirectDebitMandatesResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/directdebit/DirectDebitMandatesResponse.java
@@ -1,10 +1,10 @@
 package uk.gov.caz.psr.dto.directdebit;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import lombok.Builder;
 import lombok.Value;
 

--- a/src/main/java/uk/gov/caz/psr/dto/external/directdebit/mandates/MandateResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/external/directdebit/mandates/MandateResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.caz.psr.dto.external.directdebit.mandates;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
 import lombok.Builder;
 import lombok.Value;
 
@@ -30,7 +31,7 @@ public class MandateResponse {
   String bankStatementReference;
 
   @JsonProperty("created_date")
-  String createdDate;
+  Date createdDate;
 
   String description;
 

--- a/src/main/java/uk/gov/caz/psr/model/directdebit/Mandate.java
+++ b/src/main/java/uk/gov/caz/psr/model/directdebit/Mandate.java
@@ -1,5 +1,6 @@
 package uk.gov.caz.psr.model.directdebit;
 
+import java.util.Date;
 import lombok.Builder;
 import lombok.Value;
 
@@ -12,4 +13,5 @@ public class Mandate {
 
   String id;
   String status;
+  Date created;
 }

--- a/src/main/java/uk/gov/caz/psr/service/directdebit/DirectDebitMandatesService.java
+++ b/src/main/java/uk/gov/caz/psr/service/directdebit/DirectDebitMandatesService.java
@@ -353,7 +353,7 @@ public class DirectDebitMandatesService {
 
   /**
    * Helper value object holding two mandate statuses, the cached one and the actual one (kept
-   * externally).
+   * externally), accompanied by the external mandate creation date.
    */
   @Value
   @Builder

--- a/src/main/java/uk/gov/caz/psr/util/MandatesToDtoConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/MandatesToDtoConverter.java
@@ -24,6 +24,7 @@ public class MandatesToDtoConverter {
         .mandates(mandates.stream()
             .map(mandate -> DirectDebitMandatesResponse.CleanAirZoneWithMandates.Mandate.builder()
                 .id(mandate.getId())
+                .created(mandate.getCreated())
                 .status(mandate.getStatus()).build()
             ).collect(Collectors.toList()))
         .build();


### PR DESCRIPTION
This change is to support a JIRA task which sees revisions to content (where the created date gets shown). I've considered whether this should be added under the accounts API, however, given we are refreshing status anyway by calling out to GOV.UK PAY when hitting the /payments/accounts/<<account-id>>/direct-debit-mandates/<<mandate-id>> endpoint calls, it seems pulling the creation date through at the same time should not make any difference in performance.

The response for this endpoint is fine (and includes an iso stamped created value) as expected.

The below response (on the mandates across different CAZ's), however, does seem odd (using the mandates fetched from the account service). 

With this in mind, an approach that does store things in the Account service may still be pursued tomorrow but PR is being raised for team visibility. This latter approach does also have some downsides (as the mandate can only be created after a success call from GOV.UK PAY is returned, allowing the created date to be set properly).

` "cleanAirZones": [
        {
            "cazId": "5cd7441d-766f-48ff-b8ad-1809586fea37",
            "cazName": "Birmingham",
            "mandates": [
                {
                    "id": "8cie6doealplvd11at1hpjs6vo",
                    "status": "PENDING",
                    "created": null
                }
            ]
        },
        {`