### PR TITLE
[CAZ-2615] Return created date for direct debit mandates

### DIFF
--- a/src/it/resources/data/json/response/account-direct-debit-mandates-response.json
+++ b/src/it/resources/data/json/response/account-direct-debit-mandates-response.json
@@ -5,21 +5,24 @@
       "accountId": "36354a93-4e42-483c-ae2f-74511f6ab60e",
       "cleanAirZoneId": "53e03a28-0627-11ea-9511-ffaaee87e375",
       "paymentProviderMandateId": "i4nuo03jginfke5c3ebrvgig6a",
-      "status": "ACTIVE"
+      "status": "ACTIVE",
+      "created": "2020-04-30T08:08:31"
     },
     {
       "directDebitMandateId": "3c63bd23-1c4f-4e33-a55c-daad39114ee0",
       "accountId": "36354a93-4e42-483c-ae2f-74511f6ab60e",
       "cleanAirZoneId": "53e03a28-0627-11ea-9511-ffaaee87e375",
       "paymentProviderMandateId": "j4nuo03jginfke5c3ebrvgig6a",
-      "status": "FAILED"
+      "status": "FAILED",
+      "created": null
     },
     {
       "directDebitMandateId": "5ddb6359-d182-4188-9ebc-bb2451aa4fd1",
       "accountId": "36354a93-4e42-483c-ae2f-74511f6ab60e",
       "cleanAirZoneId": "53e03a28-0627-11ea-9511-ffaaee87e375",
       "paymentProviderMandateId": "k4nuo03jginfke5c3ebrvgig6a",
-      "status": null
+      "status": null,
+      "created": "2020-04-30T08:08:31"
     }
   ]
 }

--- a/src/it/resources/data/json/response/direct-debit-mandates-for-caz-response.json
+++ b/src/it/resources/data/json/response/direct-debit-mandates-for-caz-response.json
@@ -2,15 +2,18 @@
   "mandates": [
     {
       "id": "i4nuo03jginfke5c3ebrvgig6a",
-      "status": "CREATED"
+      "status": "CREATED",
+      "created":"2020-04-30T08:08:31"
     },
     {
       "id": "k4nuo03jginfke5c3ebrvgig6a",
-      "status": "CREATED"
+      "status": "CREATED",
+      "created":"2020-04-30T08:08:31"
     },
     {
       "id": "j4nuo03jginfke5c3ebrvgig6a",
-      "status": "FAILED"
+      "status": "FAILED",
+      "created": null
     }
   ]
 }

--- a/src/it/resources/data/json/response/direct-debit-mandates-response.json
+++ b/src/it/resources/data/json/response/direct-debit-mandates-response.json
@@ -6,15 +6,18 @@
       "mandates": [
         {
           "id": "i4nuo03jginfke5c3ebrvgig6a",
-          "status": "CREATED"
+          "status": "CREATED",
+          "created": "2020-04-30T08:08:31"
         },
         {
           "id": "k4nuo03jginfke5c3ebrvgig6a",
-          "status": "CREATED"
+          "status": "CREATED",
+          "created": "2020-04-30T08:08:31"
         },
         {
           "id": "j4nuo03jginfke5c3ebrvgig6a",
-          "status": "FAILED"
+          "status": "FAILED",
+          "created": null
         }
       ]
     },

--- a/src/main/java/uk/gov/caz/psr/dto/AccountDirectDebitMandatesResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/AccountDirectDebitMandatesResponse.java
@@ -1,5 +1,6 @@
 package uk.gov.caz.psr.dto;
 
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -30,6 +31,8 @@ public class AccountDirectDebitMandatesResponse {
 
     DirectDebitMandateStatus status;
 
+    Date created;
+    
     public enum DirectDebitMandateStatus {
       CREATED,
       STARTED,

--- a/src/main/java/uk/gov/caz/psr/dto/directdebit/DirectDebitMandatesResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/directdebit/DirectDebitMandatesResponse.java
@@ -1,5 +1,8 @@
 package uk.gov.caz.psr.dto.directdebit;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
@@ -26,9 +29,11 @@ public class DirectDebitMandatesResponse {
     @Value
     @Builder
     public static class Mandate {
-
       String id;
       String status;
+      
+      @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+      Date created;
     }
   }
 }

--- a/src/main/java/uk/gov/caz/psr/model/directdebit/Mandate.java
+++ b/src/main/java/uk/gov/caz/psr/model/directdebit/Mandate.java
@@ -1,5 +1,6 @@
 package uk.gov.caz.psr.model.directdebit;
 
+import java.util.Date;
 import lombok.Builder;
 import lombok.Value;
 
@@ -12,4 +13,5 @@ public class Mandate {
 
   String id;
   String status;
+  Date created;
 }

--- a/src/main/java/uk/gov/caz/psr/service/directdebit/DirectDebitMandatesService.java
+++ b/src/main/java/uk/gov/caz/psr/service/directdebit/DirectDebitMandatesService.java
@@ -6,6 +6,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.util.Collections;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -265,6 +266,7 @@ public class DirectDebitMandatesService {
   private Mandate toMandate(MandateWithCachedAndActualStatuses mandate) {
     return Mandate.builder()
         .id(mandate.getPaymentProviderMandateId())
+        .created(mandate.getCreated())
         .status(mandate.getActualStatus().name())
         .build();
   }
@@ -312,6 +314,7 @@ public class DirectDebitMandatesService {
         .paymentProviderMandateId(mandate.getPaymentProviderMandateId())
         .actualStatus(externalStatus)
         .cachedStatus(mandate.getStatus())
+        .created(mandate.getCreated())
         .build();
   }
 
@@ -354,7 +357,7 @@ public class DirectDebitMandatesService {
 
   /**
    * Helper value object holding two mandate statuses, the cached one and the actual one (kept
-   * externally).
+   * externally), alongside the date the mandate was created.
    */
   @Value
   @Builder
@@ -362,6 +365,9 @@ public class DirectDebitMandatesService {
 
     @NonNull
     String paymentProviderMandateId;
+    
+    Date created;
+    
     @NonNull
     DirectDebitMandateStatus actualStatus;
     DirectDebitMandateStatus cachedStatus;

--- a/src/main/java/uk/gov/caz/psr/util/CleanAirZoneWithMandatesToDtoConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/CleanAirZoneWithMandatesToDtoConverter.java
@@ -42,6 +42,7 @@ public class CleanAirZoneWithMandatesToDtoConverter {
         .map(mandate -> DirectDebitMandatesResponse.CleanAirZoneWithMandates.Mandate.builder()
             .id(mandate.getId())
             .status(mandate.getStatus())
+            .created(mandate.getCreated())
             .build())
         .collect(Collectors.toList());
   }

--- a/src/main/java/uk/gov/caz/psr/util/MandatesToDtoConverter.java
+++ b/src/main/java/uk/gov/caz/psr/util/MandatesToDtoConverter.java
@@ -24,6 +24,7 @@ public class MandatesToDtoConverter {
         .mandates(mandates.stream()
             .map(mandate -> DirectDebitMandatesResponse.CleanAirZoneWithMandates.Mandate.builder()
                 .id(mandate.getId())
+                .created(mandate.getCreated())
                 .status(mandate.getStatus()).build()
             ).collect(Collectors.toList()))
         .build();


### PR DESCRIPTION
This PR returns the date a mandate was created on GET endpoints to allow this to be surfaced in the Fleets UI layer.