### PR TITLE
[CAZ-2854] Return Operator name in API response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactFinalName>${project.artifactId}-${project.version}</artifactFinalName>
 
     <rest-assured.version>4.0.0</rest-assured.version>
-    <internal.libraries.version>2.12.2-SNAPSHOT</internal.libraries.version>
+    <internal.libraries.version>2.12.4-SNAPSHOT</internal.libraries.version>
     <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
 
     <codeCoverage.minCoveredRatio>1</codeCoverage.minCoveredRatio>

--- a/src/test/java/uk/gov/caz/psr/service/CleanAirZoneServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/CleanAirZoneServiceTest.java
@@ -24,6 +24,7 @@ public class CleanAirZoneServiceTest {
 
   private static final UUID ANY_VALID_CAZ_ID = UUID.randomUUID();
   private static final String ANY_VALID_CAZ_NAME = "CAZ_NAME";
+  private static final String ANY_VALID_OPERATOR_NAME = "OPERATOR_NAME";
 
   @InjectMocks
   private CleanAirZoneService cleanAirZoneService;
@@ -85,6 +86,8 @@ public class CleanAirZoneServiceTest {
     // then
     assertThat(result).isNotNull();
     assertThat(result.getBody().getCleanAirZones().get(0).getName()).isEqualTo(ANY_VALID_CAZ_NAME);
+    assertThat(result.getBody().getCleanAirZones().get(0).getOperatorName())
+        .isEqualTo(ANY_VALID_OPERATOR_NAME);
   }
 
   private void mockRepositoryResultForCleanAirZones() {
@@ -97,6 +100,7 @@ public class CleanAirZoneServiceTest {
             CleanAirZoneDto.builder()
                 .cleanAirZoneId(ANY_VALID_CAZ_ID)
                 .name(ANY_VALID_CAZ_NAME)
+                .operatorName(ANY_VALID_OPERATOR_NAME)
                 .activeChargeStartDate("2018-10-18")
                 .build()))
         .build());


### PR DESCRIPTION
Jira card: https://eaflood.atlassian.net/browse/CAZ-2854
Added OperatorName to the response of /payments/clean-air-zones endpoint:

