### PR TITLE
[CAZB-2164] AccountsPayments endpoint

### DIFF
--- a/src/it/java/uk/gov/caz/psr/ExternalCallsIT.java
+++ b/src/it/java/uk/gov/caz/psr/ExternalCallsIT.java
@@ -194,6 +194,13 @@ public class ExternalCallsIT {
         .respond(emptyResponse(statusCode));
   }
 
+  public void mockAccountServiceGetAllUsersCall(String accountId, int statusCode) {
+    accountsMockServer
+        .when(requestGet("/v1/accounts/" + accountId + "/users"),
+            exactly(1))
+        .respond(response("account-users-list-response.json", statusCode));
+  }
+
   @SneakyThrows
   private String readFile(String filename) {
     return Resources.toString(Resources.getResource("data/external/" + filename),

--- a/src/it/java/uk/gov/caz/psr/RetrieveSuccessfulPaymentsTestIT.java
+++ b/src/it/java/uk/gov/caz/psr/RetrieveSuccessfulPaymentsTestIT.java
@@ -1,0 +1,86 @@
+package uk.gov.caz.psr;
+
+import io.restassured.RestAssured;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import uk.gov.caz.psr.annotation.FullyRunningServerIntegrationTest;
+import uk.gov.caz.psr.journeys.RetrieveSuccessfulPaymentsJourneyAssertion;
+
+@Sql(scripts = "classpath:data/sql/add-caz-entrant-payments.sql",
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:data/sql/clear-all-payments.sql",
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
+@FullyRunningServerIntegrationTest
+public class RetrieveSuccessfulPaymentsTestIT extends ExternalCallsIT {
+
+  private static final String ANY_ACCOUNT_ID = UUID.randomUUID().toString();
+  private static final String OWNER_USER_UD = "ab3e9f4b-4076-4154-b6dd-97c5d4800b47";
+  private static final String NON_EXISTING_USER_ID = "cd5b8fbc-f106-4726-96ea-ef76d1136cd8";
+
+  private static final String ANY_PAGE_NUMBER = "0";
+  private static final String ANY_PAGE_SIZE = "10";
+
+  @LocalServerPort
+  int randomServerPort;
+
+  @BeforeEach
+  public void setupRestAssured() {
+    RestAssured.port = randomServerPort;
+    RestAssured.baseURI = "http://localhost";
+  }
+
+  @Test
+  public void shouldReturn200OkResponseWhenValidRequestForAllUsersAssociatedWithAccount() {
+    mockAccountServiceGetAllUsersCall(ANY_ACCOUNT_ID, 200);
+    mockVccsCleanAirZonesCall();
+
+    givenSuccessfulPaymentsRetrieval()
+        .forAccountId(ANY_ACCOUNT_ID)
+        .forPageNumber(ANY_PAGE_NUMBER)
+        .forPageSize(ANY_PAGE_SIZE)
+        .whenRequestIsMade()
+        .then()
+        .responseIsReturnedWithHttpOkStatusCode()
+        .responseIncludeDataOfAllUsers();
+  }
+
+  @Test
+  public void shouldReturn200OkResponseWhenValidRequestForSingleUser() {
+    mockAccountServiceGetAllUsersCall(ANY_ACCOUNT_ID, 200);
+    mockVccsCleanAirZonesCall();
+
+    givenSuccessfulPaymentsRetrieval()
+        .forAccountId(ANY_ACCOUNT_ID)
+        .forAccountUserId(OWNER_USER_UD)
+        .forPageNumber(ANY_PAGE_NUMBER)
+        .forPageSize(ANY_PAGE_SIZE)
+        .whenRequestIsMade()
+        .then()
+        .responseIsReturnedWithHttpOkStatusCode()
+        .responseIncludeDataOfASingleUser();
+  }
+
+  @Test
+  public void shouldReturn200OkEmptyResponseWhenRequestingNonAssociatedUser() {
+    mockAccountServiceGetAllUsersCall(ANY_ACCOUNT_ID, 200);
+    mockVccsCleanAirZonesCall();
+
+    givenSuccessfulPaymentsRetrieval()
+        .forAccountId(ANY_ACCOUNT_ID)
+        .forAccountUserId(NON_EXISTING_USER_ID)
+        .forPageNumber(ANY_PAGE_NUMBER)
+        .forPageSize(ANY_PAGE_SIZE)
+        .whenRequestIsMade()
+        .then()
+        .responseIsReturnedWithHttpOkStatusCode()
+        .responseHadNoData();
+  }
+
+  private RetrieveSuccessfulPaymentsJourneyAssertion givenSuccessfulPaymentsRetrieval() {
+    return new RetrieveSuccessfulPaymentsJourneyAssertion();
+  }
+}

--- a/src/it/java/uk/gov/caz/psr/journeys/RetrieveSuccessfulPaymentsJourneyAssertion.java
+++ b/src/it/java/uk/gov/caz/psr/journeys/RetrieveSuccessfulPaymentsJourneyAssertion.java
@@ -1,0 +1,120 @@
+package uk.gov.caz.psr.journeys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.MediaType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import uk.gov.caz.correlationid.Constants;
+import uk.gov.caz.psr.controller.AccountsController;
+import uk.gov.caz.psr.dto.SuccessfulPaymentsResponse;
+
+@RequiredArgsConstructor
+public class RetrieveSuccessfulPaymentsJourneyAssertion {
+
+  private String accountId;
+  private String accountUserId;
+  private String pageNumber;
+  private String pageSize;
+
+  private ValidatableResponse response;
+  private SuccessfulPaymentsResponse successfulPaymentsResponse;
+
+  private static final String CORRELATION_ID = UUID.randomUUID().toString();
+
+  public RetrieveSuccessfulPaymentsJourneyAssertion forAccountId(String accountId) {
+    this.accountId = accountId;
+    return this;
+  }
+
+  public RetrieveSuccessfulPaymentsJourneyAssertion forAccountUserId(String accountUserId) {
+    this.accountUserId = accountUserId;
+    return this;
+  }
+
+  public RetrieveSuccessfulPaymentsJourneyAssertion forPageNumber(String pageNumber) {
+    this.pageNumber = pageNumber;
+    return this;
+  }
+
+  public RetrieveSuccessfulPaymentsJourneyAssertion forPageSize(String pageSize) {
+    this.pageSize = pageSize;
+    return this;
+  }
+
+  public RetrieveSuccessfulPaymentsJourneyAssertion whenRequestIsMade() {
+    RestAssured.basePath = AccountsController.ACCOUNTS_PATH;
+
+    this.response = prepareRequestWithParams()
+        .when()
+        .get("/{accountId}/payments")
+        .then();
+
+    return this;
+  }
+
+  private RequestSpecification prepareRequestWithParams() {
+    RequestSpecification request = RestAssured
+        .given()
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .header(Constants.X_CORRELATION_ID_HEADER, CORRELATION_ID)
+        .pathParam("accountId", this.accountId)
+        .queryParam("pageNumber", this.pageNumber)
+        .queryParam("pageSize", this.pageSize);
+
+    return this.accountUserId == null
+        ? request
+        : request.queryParam("accountUserId", this.accountUserId);
+  }
+
+  public RetrieveSuccessfulPaymentsJourneyAssertion then() {
+    return this;
+  }
+
+  public RetrieveSuccessfulPaymentsJourneyAssertion responseIsReturnedWithHttpOkStatusCode() {
+    this.successfulPaymentsResponse = response
+        .statusCode(HttpStatus.OK.value())
+        .header(Constants.X_CORRELATION_ID_HEADER, CORRELATION_ID)
+        .extract()
+        .as(SuccessfulPaymentsResponse.class);
+
+    return this;
+  }
+
+  public void responseHadNoData() {
+    SuccessfulPaymentsResponse response = this.successfulPaymentsResponse;
+
+    assertThat(response.getTotalPaymentsCount()).isEqualTo(0);
+    assertThat(response.getPageCount()).isEqualTo(0);
+    assertThat(response.getPayments()).isEmpty();
+  }
+
+  public void responseIncludeDataOfAllUsers() {
+    SuccessfulPaymentsResponse response = this.successfulPaymentsResponse;
+
+    assertThat(response.getTotalPaymentsCount()).isEqualTo(2);
+    assertThat(getPayersNames().size()).isEqualTo(2);
+  }
+
+  public void responseIncludeDataOfASingleUser() {
+    SuccessfulPaymentsResponse response = this.successfulPaymentsResponse;
+
+    assertThat(response.getTotalPaymentsCount()).isEqualTo(1);
+    assertThat(getPayersNames().size()).isEqualTo(1);
+  }
+
+  private Set<String> getPayersNames() {
+    return this.successfulPaymentsResponse
+        .getPayments()
+        .stream()
+        .map(payment -> payment.getPayerName())
+        .collect(Collectors.toSet());
+  }
+}

--- a/src/it/resources/data/external/get-clean-air-zones.json
+++ b/src/it/resources/data/external/get-clean-air-zones.json
@@ -11,6 +11,12 @@
       "cleanAirZoneId": "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
       "boundaryUrl": "https://cleanairleeds.co.uk",
       "activeChargeStartDate": "2018-10-29"
+    },
+    {
+      "name": "Bath",
+      "cleanAirZoneId": "b8e53786-c5ca-426a-a701-b14ee74857d4",
+      "boundaryUrl": "https://www.bathnes.gov.uk/bath-breathes-2021-overview/the-zone-boundary",
+      "activeChargeStartDate": "2018-10-30"
     }
   ]
 }

--- a/src/it/resources/data/json/response/account-users-list-response.json
+++ b/src/it/resources/data/json/response/account-users-list-response.json
@@ -1,0 +1,25 @@
+{
+    "users": [
+    {
+        "accountUserId": "ab3e9f4b-4076-4154-b6dd-97c5d4800b47",
+        "name": "",
+        "email": "owner@email.com",
+        "owner": true,
+        "removed": false
+    },
+    {
+        "accountUserId": "88732cca-a5c7-4ad6-a60d-7edede935915",
+        "name": "Jan Kowalski",
+        "email": "user@email.com",
+        "owner": false,
+        "removed": false
+    },
+    {
+        "accountUserId": "3f319922-71d2-432c-9757-8e5f060c2447",
+        "name": "",
+        "email": "",
+        "owner": false,
+        "removed": true
+    }
+  ]
+}

--- a/src/it/resources/data/json/response/direct-debit-mandates-response-without-mandates.json
+++ b/src/it/resources/data/json/response/direct-debit-mandates-response-without-mandates.json
@@ -9,6 +9,11 @@
       "cazId" : "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
       "cazName": "Leeds",
       "mandates": []
+    },
+    {
+      "cazId": "b8e53786-c5ca-426a-a701-b14ee74857d4",
+      "cazName": "Bath",
+      "mandates": []
     }
   ]
 }

--- a/src/it/resources/data/json/response/direct-debit-mandates-response.json
+++ b/src/it/resources/data/json/response/direct-debit-mandates-response.json
@@ -25,6 +25,11 @@
       "cazId" : "39e54ed8-3ed2-441d-be3f-38fc9b70c8d3",
       "cazName": "Leeds",
       "mandates": []
+    },
+    {
+      "cazId": "b8e53786-c5ca-426a-a701-b14ee74857d4",
+      "cazName": "Bath",
+      "mandates": []
     }
   ]
 }

--- a/src/it/resources/data/sql/add-caz-entrant-payments.sql
+++ b/src/it/resources/data/sql/add-caz-entrant-payments.sql
@@ -1,9 +1,9 @@
 INSERT INTO caz_payment.t_payment(
-	payment_id, payment_method, payment_provider_id, total_paid, payment_provider_status, payment_submitted_timestamp, payment_authorised_timestamp)
+	payment_id, user_id, payment_method, payment_provider_id, total_paid, payment_provider_status, payment_submitted_timestamp, payment_authorised_timestamp)
 	VALUES
-	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'CREDIT_DEBIT_CARD', '12345test', 100, 'SUCCESS', now(), now()),
-	  ('dabc1391-ff31-427a-8000-69037deb2d3a', 'CREDIT_DEBIT_CARD', '98765test', 100, 'SUCCESS', now(), now()),
-	  ('1d378f50-3326-412a-b663-cd080744f1f1', 'CREDIT_DEBIT_CARD', null, 100, null, null, null);
+	  ('b71b72a5-902f-4a16-a91d-1a4463b801db', 'ab3e9f4b-4076-4154-b6dd-97c5d4800b47', 'CREDIT_DEBIT_CARD', '12345test', 100, 'SUCCESS', now(), now()),
+	  ('dabc1391-ff31-427a-8000-69037deb2d3a', '88732cca-a5c7-4ad6-a60d-7edede935915', 'CREDIT_DEBIT_CARD', '98765test', 100, 'SUCCESS', now(), now()),
+	  ('1d378f50-3326-412a-b663-cd080744f1f1', '3f319922-71d2-432c-9757-8e5f060c2447', 'CREDIT_DEBIT_CARD', null, 100, null, null, null);
 
 INSERT INTO caz_payment.t_clean_air_zone_entrant_payment(
 	clean_air_zone_entrant_payment_id, vrn, clean_air_zone_id, travel_date, tariff_code, charge, payment_status, update_actor)

--- a/src/main/java/uk/gov/caz/psr/controller/AccountControllerApiSpec.java
+++ b/src/main/java/uk/gov/caz/psr/controller/AccountControllerApiSpec.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.caz.correlationid.Constants;
 import uk.gov.caz.psr.dto.ChargeableAccountVehicleResponse;
+import uk.gov.caz.psr.dto.SuccessfulPaymentsResponse;
 import uk.gov.caz.psr.dto.VehicleRetrievalResponseDto;
 
 @RequestMapping(value = ACCOUNTS_PATH, produces = {MediaType.APPLICATION_JSON_VALUE})
@@ -31,31 +32,31 @@ public interface AccountControllerApiSpec {
       response = VehicleRetrievalResponseDto.class)
   @ApiResponses({
       @ApiResponse(code = 500, message = "Internal Server Error / No message available"),
-      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory " 
+      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory "
           + "element)"),
       @ApiResponse(code = 404, message = "Account not found"),
       @ApiResponse(code = 429, message = "Too many requests")
-    })
+  })
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "account_id", 
+      @ApiImplicitParam(name = "account_id",
           required = true,
-          value = "The identifier of the account to retrieve vehicles for", 
+          value = "The identifier of the account to retrieve vehicles for",
           paramType = "path"),
-      @ApiImplicitParam(name = Constants.X_CORRELATION_ID_HEADER, 
+      @ApiImplicitParam(name = Constants.X_CORRELATION_ID_HEADER,
           required = true,
           value = "UUID formatted string to track the request through the enquiries stack",
           paramType = "header"),
-      @ApiImplicitParam(name = "pageNumber", 
+      @ApiImplicitParam(name = "pageNumber",
           required = true,
-          value = "The number of the page to retrieve", 
+          value = "The number of the page to retrieve",
           paramType = "query"),
-      @ApiImplicitParam(name = "pageSize", 
+      @ApiImplicitParam(name = "pageSize",
           required = true,
-          value = "The size of the page to retrieve", 
+          value = "The size of the page to retrieve",
           paramType = "query"),
-      @ApiImplicitParam(name = "zones", 
+      @ApiImplicitParam(name = "zones",
           required = true,
-          value = "The clean air zones for which to return charges", 
+          value = "The clean air zones for which to return charges",
           paramType = "query")})
   @GetMapping("/{accountId}/charges")
   ResponseEntity<VehicleRetrievalResponseDto> retrieveVehiclesAndCharges(
@@ -71,75 +72,110 @@ public interface AccountControllerApiSpec {
       response = ChargeableAccountVehicleResponse.class)
   @ApiResponses({
       @ApiResponse(code = 500, message = "Internal Server Error / No message available"),
-      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory " 
+      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory "
           + "element)"),
       @ApiResponse(code = 404, message = "Account not found"),
       @ApiResponse(code = 429, message = "Too many requests"),
-    })
+  })
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "account_id", 
+      @ApiImplicitParam(name = "account_id",
           required = true,
-          value = "The identifier of the account to retrieve vehicles for", 
+          value = "The identifier of the account to retrieve vehicles for",
           paramType = "path"),
-      @ApiImplicitParam(name = Constants.X_CORRELATION_ID_HEADER, 
+      @ApiImplicitParam(name = Constants.X_CORRELATION_ID_HEADER,
           required = true,
           value = "UUID formatted string to track the request through the enquiries stack",
           paramType = "header"),
-      @ApiImplicitParam(name = "cleanAirZoneId", 
+      @ApiImplicitParam(name = "cleanAirZoneId",
           required = true,
-          value = "The clean air zones for which to return charges", 
+          value = "The clean air zones for which to return charges",
           paramType = "query"),
-      @ApiImplicitParam(name = "direction", 
+      @ApiImplicitParam(name = "direction",
           required = true,
           value = "Either 'next' or 'previous', determines the direction of the paging sort",
           paramType = "query"),
-      @ApiImplicitParam(name = "pageSize", 
+      @ApiImplicitParam(name = "pageSize",
           required = true,
-          value = "The size of the page to retrieve", 
+          value = "The size of the page to retrieve",
           paramType = "query"),
-      @ApiImplicitParam(name = "vrn", 
+      @ApiImplicitParam(name = "vrn",
           required = true,
-          value = "The vrn to use as a cursor for the pagination", 
+          value = "The vrn to use as a cursor for the pagination",
           paramType = "query")})
   @GetMapping("/{accountId}/chargeable-vehicles")
   ResponseEntity<ChargeableAccountVehicleResponse> retrieveChargeableVehicles(
       @PathVariable("accountId") UUID accountId,
       @RequestParam(required = true) Map<String, String> queryStrings);
 
-
   /**
    * An endpoint to retrieve a single chargeable vehicle registered against an account.
    *
    * @return {@link ChargeableAccountVehicleResponse} wrapped in {@link ResponseEntity}.
    */
-  @ApiOperation(value = "${swagger.operations.accounts.chargeable-vehicles.vrn.description}",
+  @ApiOperation(value = "${swagger.operations.accounts.chargeable-vehicles.description}",
       response = ChargeableAccountVehicleResponse.class)
   @ApiResponses({
       @ApiResponse(code = 500, message = "Internal Server Error / No message available"),
-      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory " 
+      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory "
           + "element)"),
       @ApiResponse(code = 404, message = "Account vehicle not found"),
       @ApiResponse(code = 429, message = "Too many requests"),
-    })
+  })
   @ApiImplicitParams({
-      @ApiImplicitParam(name = "account_id", 
+      @ApiImplicitParam(name = "account_id",
           required = true,
-          value = "The identifier of the account to retrieve vehicles for", 
+          value = "The identifier of the account to retrieve vehicles for",
           paramType = "path"),
-      @ApiImplicitParam(name = Constants.X_CORRELATION_ID_HEADER, 
+      @ApiImplicitParam(name = Constants.X_CORRELATION_ID_HEADER,
           required = true,
           value = "UUID formatted string to track the request through the enquiries stack",
           paramType = "header"),
-      @ApiImplicitParam(name = "cleanAirZoneId", 
+      @ApiImplicitParam(name = "cleanAirZoneId",
           required = true,
-          value = "The clean air zones for which to return charges", 
+          value = "The clean air zones for which to return charges",
           paramType = "query"),
-      @ApiImplicitParam(name = "vrn", 
+      @ApiImplicitParam(name = "vrn",
           required = true,
-          value = "The vrn to query", 
+          value = "The vrn to query",
           paramType = "path")})
   @GetMapping("/{accountId}/chargeable-vehicles/{vrn}")
   ResponseEntity<ChargeableAccountVehicleResponse> retrieveSingleChargeableVehicle(
-      @PathVariable("accountId") UUID accountId, @PathVariable("vrn") String vrn, 
+      @PathVariable("accountId") UUID accountId, @PathVariable("vrn") String vrn,
+      @RequestParam(required = true) Map<String, String> queryStrings);
+
+  /**
+   * An endpoint to retrieve successful payments data of a user associated with a specific account.
+   *
+   * @return {@link SuccessfulPaymentsResponse} wrapped in {@link ResponseEntity}.
+   */
+  @ApiOperation(value = "${swagger.operations.accounts.successful-payments.description}",
+      response = SuccessfulPaymentsResponse.class)
+  @ApiResponses({
+      @ApiResponse(code = 500, message = "Internal Server Error / No message available"),
+      @ApiResponse(code = 400, message = "Bad Request (the request is missing a mandatory "
+          + "element)"),
+      @ApiResponse(code = 404, message = "Account not found")
+  })
+  @ApiImplicitParams({
+      @ApiImplicitParam(name = "accountId",
+          required = true,
+          value = "The identifier of the account to retrieve payments data",
+          paramType = "path"),
+      @ApiImplicitParam(name = "accountUserId",
+          required = true,
+          value = "The identifier of the account user",
+          paramType = "query"),
+      @ApiImplicitParam(name = "pageNumber",
+          required = true,
+          value = "The number of the page to retrieve",
+          paramType = "query"),
+      @ApiImplicitParam(name = "pageSize",
+          required = true,
+          value = "The size of the page to retrieve",
+          paramType = "query")
+  })
+  @GetMapping("/{accountId}/payments")
+  ResponseEntity<SuccessfulPaymentsResponse> retrieveSuccessfulPayments(
+      @PathVariable("accountId") UUID accountId,
       @RequestParam(required = true) Map<String, String> queryStrings);
 }

--- a/src/main/java/uk/gov/caz/psr/dto/SuccessfulPaymentsResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/SuccessfulPaymentsResponse.java
@@ -1,0 +1,55 @@
+package uk.gov.caz.psr.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+import uk.gov.caz.psr.model.EnrichedPaymentSummary;
+import uk.gov.caz.psr.model.PaginationData;
+
+/**
+ * A class that represents a response with payments data of a specific user.
+ */
+@Value
+@Builder
+public class SuccessfulPaymentsResponse {
+
+  /**
+   * Page that has been retrieved.
+   */
+  int page;
+
+  /**
+   * Total number of pages available (with current page size).
+   */
+  int pageCount;
+
+  /**
+   * The current page size.
+   */
+  int perPage;
+
+  /**
+   * The total number of successful payments associated with the account.
+   */
+  int totalPaymentsCount;
+
+  /**
+   * A list of payments data.
+   */
+  List<EnrichedPaymentSummary> payments;
+
+  /**
+   * Helper method which composes response object from the provided {@link PaginationData} and list
+   * of {@link EnrichedPaymentSummary}.
+   */
+  public static SuccessfulPaymentsResponse from(PaginationData paginationData,
+      List<EnrichedPaymentSummary> payments) {
+    return SuccessfulPaymentsResponse.builder()
+        .perPage(paginationData.getPageSize())
+        .totalPaymentsCount(paginationData.getTotalElementsCount())
+        .page(paginationData.getPageNumber())
+        .pageCount(paginationData.getPageCount())
+        .payments(payments)
+        .build();
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/dto/accounts/AccountUserResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/accounts/AccountUserResponse.java
@@ -1,0 +1,38 @@
+package uk.gov.caz.psr.dto.accounts;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Class that represents the JSON structure for response from the Accounts API.
+ */
+@Value
+@Builder
+public class AccountUserResponse {
+
+  /**
+   * Id of User in DB.
+   */
+  UUID accountUserId;
+
+  /**
+   * Name of the User from the Identity Provider.
+   */
+  String name;
+
+  /**
+   * Email of the User from the Identity Provider.
+   */
+  String email;
+
+  /**
+   * Boolean specifying whether the user is an owner.
+   */
+  boolean owner;
+
+  /**
+   * Boolean specifying whether the user is removed.
+   */
+  boolean removed;
+}

--- a/src/main/java/uk/gov/caz/psr/dto/accounts/AccountUsersResponse.java
+++ b/src/main/java/uk/gov/caz/psr/dto/accounts/AccountUsersResponse.java
@@ -1,0 +1,18 @@
+package uk.gov.caz.psr.dto.accounts;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Class that represents the JSON structure for User for Account retrieval response.
+ */
+@Value
+@Builder
+public class AccountUsersResponse {
+
+  /**
+   * The list of VRNs associated with the account ID provided in the request.
+   */
+  List<AccountUserResponse> users;
+}

--- a/src/main/java/uk/gov/caz/psr/model/EnrichedPaymentSummary.java
+++ b/src/main/java/uk/gov/caz/psr/model/EnrichedPaymentSummary.java
@@ -1,0 +1,38 @@
+package uk.gov.caz.psr.model;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Class that enriches {@link PaymentSummary} with data coming from Accounts API and VCCS API.
+ */
+@Value
+@Builder
+public class EnrichedPaymentSummary {
+
+  /**
+   * Id of the payment.
+   */
+  UUID paymentId;
+
+  /**
+   * Quantity of the payed entries to CAZ.
+   */
+  int entriesCount;
+
+  /**
+   * Total amount paid.
+   */
+  int totalPaid;
+
+  /**
+   * Name of the Clean Air Zone.
+   */
+  String cazName;
+
+  /**
+   * Name of the payer.
+   */
+  String payerName;
+}

--- a/src/main/java/uk/gov/caz/psr/model/PaginationData.java
+++ b/src/main/java/uk/gov/caz/psr/model/PaginationData.java
@@ -1,0 +1,32 @@
+package uk.gov.caz.psr.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Class responsible for storing information about pagination.
+ */
+@Value
+@Builder
+public class PaginationData {
+
+  /**
+   * Page number.
+   */
+  int pageNumber;
+
+  /**
+   * Size of the page.
+   */
+  int pageSize;
+
+  /**
+   * Quantity of all the elements stored in the data source.
+   */
+  int totalElementsCount;
+
+  /**
+   * Quantity of pages for the provided page size.
+   */
+  int pageCount;
+}

--- a/src/main/java/uk/gov/caz/psr/model/PaymentSummary.java
+++ b/src/main/java/uk/gov/caz/psr/model/PaymentSummary.java
@@ -1,0 +1,39 @@
+package uk.gov.caz.psr.model;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * An entity which represent a compound response from the DB from {@code PAYMENT}, {@code
+ * VEHICLE_ENTRANT_PAYMENT} and {@code VEHICLE_ENTRANT_PAYMENT_MATCH} tables.
+ */
+@Value
+@Builder(toBuilder = true)
+public class PaymentSummary {
+
+  /**
+   * ID of the payment.
+   */
+  UUID paymentId;
+
+  /**
+   * Quantity of the payed entries to CAZ.
+   */
+  int entriesCount;
+
+  /**
+   * Total amount paid.
+   */
+  int totalPaid;
+
+  /**
+   * ID of the Clean Air Zone.
+   */
+  UUID cleanAirZoneId;
+
+  /**
+   * ID of the payer user.
+   */
+  UUID payerId;
+}

--- a/src/main/java/uk/gov/caz/psr/model/PaymentToCleanAirZoneMapping.java
+++ b/src/main/java/uk/gov/caz/psr/model/PaymentToCleanAirZoneMapping.java
@@ -1,0 +1,24 @@
+package uk.gov.caz.psr.model;
+
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Class that stores information about payment ID and clean air zone ID which the payment is
+ * associated with.
+ */
+@Value
+@Builder(toBuilder = true)
+public class PaymentToCleanAirZoneMapping {
+
+  /**
+   * ID of the Clean Air Zone.
+   */
+  UUID cleanAirZoneId;
+
+  /**
+   * ID of the payment.
+   */
+  UUID paymentId;
+}

--- a/src/main/java/uk/gov/caz/psr/repository/AccountsRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/AccountsRepository.java
@@ -15,6 +15,7 @@ import retrofit2.http.Query;
 import uk.gov.caz.psr.dto.AccountDirectDebitMandatesResponse;
 import uk.gov.caz.psr.dto.AccountVehicleResponse;
 import uk.gov.caz.psr.dto.AccountVehicleRetrievalResponse;
+import uk.gov.caz.psr.dto.accounts.AccountUsersResponse;
 import uk.gov.caz.psr.dto.accounts.CreateDirectDebitMandateRequest;
 import uk.gov.caz.psr.dto.accounts.CreateDirectDebitMandateResponse;
 import uk.gov.caz.psr.dto.accounts.DirectDebitMandatesUpdateRequest;
@@ -176,6 +177,26 @@ public interface AccountsRepository {
       DirectDebitMandatesUpdateRequest body) {
     try {
       return updateDirectDebitMandates(accountId, body).execute();
+    } catch (IOException e) {
+      throw new ExternalServiceCallException(e.getMessage());
+    }
+  }
+
+  /**
+   * Method to get all users associated with the provided account.
+   */
+  @Headers({
+      "Accept: application/json"
+  })
+  @GET("v1/accounts/{accountId}/users")
+  Call<AccountUsersResponse> getAllUsers(@Path("accountId") UUID accountId);
+
+  /**
+   * A synchronous wrapper for {@code getAllUsers} call.
+   */
+  default Response<AccountUsersResponse> getAllUsersSync(UUID accountId) {
+    try {
+      return getAllUsers(accountId).execute();
     } catch (IOException e) {
       throw new ExternalServiceCallException(e.getMessage());
     }

--- a/src/main/java/uk/gov/caz/psr/repository/PaymentSummaryRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/PaymentSummaryRepository.java
@@ -1,0 +1,101 @@
+package uk.gov.caz.psr.repository;
+
+import com.google.common.base.Preconditions;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import uk.gov.caz.psr.model.PaymentSummary;
+
+/**
+ * A repository responsible for fetching {@link PaymentSummary} objects.
+ */
+@Repository
+@AllArgsConstructor
+public class PaymentSummaryRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private static final PaymentSummaryMapper ROW_MAPPER = new PaymentSummaryMapper();
+
+  private static final String SELECT_PAGINATED_PAYMENTS_SUMMARIES = "SELECT "
+      + "t_payment.payment_id, "
+      + "t_payment.total_paid, "
+      + "t_payment.user_id as payer_id, "
+      + "(SELECT COUNT(*) FROM caz_payment.t_clean_air_zone_entrant_payment_match "
+      + "WHERE t_payment.payment_id = t_clean_air_zone_entrant_payment_match.payment_id) "
+      + "AS entries_count "
+      + "FROM caz_payment.t_payment "
+      + "WHERE user_id = ANY (?) "
+      + "AND payment_provider_status = 'SUCCESS' "
+      + "ORDER BY t_payment.insert_timestamp DESC "
+      + "LIMIT ? "
+      + "OFFSET ?";
+
+  private static final String SELECT_PAYMENT_SUMMARIES_COUNT_FOR_USER_IDS = "SELECT count(*) "
+      + "FROM caz_payment.t_payment "
+      + "WHERE user_id = ANY (?) "
+      + "AND payment_provider_status = 'SUCCESS'";
+
+  /**
+   * Method responsible for fetching paginated payments data for the provided users.
+   *
+   * @param userIds List of the user ids.
+   * @param pageNumber page number
+   * @param pageSize page size
+   * @return List of {@link PaymentSummary}.
+   */
+  public List<PaymentSummary> getPaginatedPaymentSummaryForUserIds(List<UUID> userIds,
+      int pageNumber, int pageSize) {
+    Preconditions.checkNotNull(userIds, "userIds cannot be null.");
+
+    return jdbcTemplate.query(connection -> {
+      PreparedStatement preparedStatement = connection.prepareStatement(
+          SELECT_PAGINATED_PAYMENTS_SUMMARIES);
+      preparedStatement.setArray(1, connection.createArrayOf("uuid", userIds.toArray()));
+      preparedStatement.setInt(2, pageSize);
+      preparedStatement.setInt(3, pageNumber * pageSize);
+      return preparedStatement;
+    }, ROW_MAPPER);
+  }
+
+  /**
+   * Method responsible for getting payments count for the provided users.
+   *
+   * @param userIds list of the user ids.
+   * @return payments count.
+   */
+  public Integer getTotalPaymentsCountForUserIds(List<UUID> userIds) {
+    Preconditions.checkNotNull(userIds, "userIds cannot be null.");
+
+    List<Integer> result = jdbcTemplate.query(connection -> {
+      PreparedStatement preparedStatement = connection.prepareStatement(
+          SELECT_PAYMENT_SUMMARIES_COUNT_FOR_USER_IDS);
+      preparedStatement.setArray(1, connection.createArrayOf("uuid", userIds.toArray()));
+      return preparedStatement;
+    }, (resultSet, i) -> resultSet.getInt("count"));
+
+    return result.iterator().next();
+  }
+
+  /**
+   * A class which maps the results obtained from the database to instances of {@link
+   * PaymentSummary} class.
+   */
+  private static class PaymentSummaryMapper implements RowMapper<PaymentSummary> {
+
+    @Override
+    public PaymentSummary mapRow(ResultSet resultSet, int i) throws SQLException {
+      return PaymentSummary.builder()
+          .paymentId(UUID.fromString(resultSet.getString("payment_id")))
+          .totalPaid(resultSet.getInt("total_paid"))
+          .payerId(UUID.fromString(resultSet.getString("payer_id")))
+          .entriesCount(resultSet.getInt("entries_count"))
+          .build();
+    }
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/repository/PaymentToCleanAirZoneMappingRepository.java
+++ b/src/main/java/uk/gov/caz/psr/repository/PaymentToCleanAirZoneMappingRepository.java
@@ -1,0 +1,69 @@
+package uk.gov.caz.psr.repository;
+
+import com.google.common.base.Preconditions;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import uk.gov.caz.psr.model.PaymentToCleanAirZoneMapping;
+
+/**
+ * Repository responsible for getting {@link PaymentToCleanAirZoneMapping} objects.
+ */
+@Repository
+@AllArgsConstructor
+public class PaymentToCleanAirZoneMappingRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private static final PaymentToCleanAirZoneRowMapper ROW_MAPPER =
+      new PaymentToCleanAirZoneRowMapper();
+
+  private static final String SELECT_MAPPING_FOR_USER_IDS =
+      "SELECT DISTINCT ep.clean_air_zone_id, tp.payment_id FROM caz_payment.t_payment tp "
+          + "INNER JOIN caz_payment.t_clean_air_zone_entrant_payment_match epm "
+          + "ON tp.payment_id = epm.payment_id "
+          + "INNER JOIN caz_payment.t_clean_air_zone_entrant_payment ep "
+          + "ON epm.clean_air_zone_entrant_payment_id = ep.clean_air_zone_entrant_payment_id "
+          + "WHERE epm.clean_air_zone_entrant_payment_id = ep.clean_air_zone_entrant_payment_id "
+          + "AND tp.user_id = ANY (?)";
+
+  /**
+   * Method receives list of userIds and fetches information about their payments and cleanAirZones
+   * with which those payments are associated.
+   *
+   * @param userIds list of user ids.
+   * @return list of payment to caz mappings.
+   */
+  public List<PaymentToCleanAirZoneMapping> getPaymentToCleanAirZoneMapping(List<UUID> userIds) {
+    Preconditions.checkNotNull(userIds, "userIds cannot be null.");
+
+    return jdbcTemplate.query(connection -> {
+      PreparedStatement preparedStatement = connection.prepareStatement(
+          SELECT_MAPPING_FOR_USER_IDS);
+      preparedStatement.setArray(1,
+          connection.createArrayOf("uuid", userIds.toArray()));
+      return preparedStatement;
+    }, ROW_MAPPER);
+  }
+
+  /**
+   * A class which maps the results obtained from the database to instances of {@link
+   * PaymentToCleanAirZoneMapping} class.
+   */
+  private static class PaymentToCleanAirZoneRowMapper implements
+      RowMapper<PaymentToCleanAirZoneMapping> {
+
+    @Override
+    public PaymentToCleanAirZoneMapping mapRow(ResultSet resultSet, int i) throws SQLException {
+      return PaymentToCleanAirZoneMapping.builder()
+          .cleanAirZoneId(UUID.fromString(resultSet.getString("clean_air_zone_id")))
+          .paymentId(UUID.fromString(resultSet.getString("payment_id")))
+          .build();
+    }
+  }
+}

--- a/src/main/java/uk/gov/caz/psr/service/RetrieveSuccessfulPaymentsService.java
+++ b/src/main/java/uk/gov/caz/psr/service/RetrieveSuccessfulPaymentsService.java
@@ -1,0 +1,241 @@
+package uk.gov.caz.psr.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import retrofit2.Response;
+import uk.gov.caz.definitions.dto.CleanAirZoneDto;
+import uk.gov.caz.definitions.dto.CleanAirZonesDto;
+import uk.gov.caz.psr.dto.accounts.AccountUserResponse;
+import uk.gov.caz.psr.dto.accounts.AccountUsersResponse;
+import uk.gov.caz.psr.model.EnrichedPaymentSummary;
+import uk.gov.caz.psr.model.PaginationData;
+import uk.gov.caz.psr.model.PaymentSummary;
+import uk.gov.caz.psr.model.PaymentToCleanAirZoneMapping;
+import uk.gov.caz.psr.repository.AccountsRepository;
+import uk.gov.caz.psr.repository.PaymentSummaryRepository;
+import uk.gov.caz.psr.repository.PaymentToCleanAirZoneMappingRepository;
+import uk.gov.caz.psr.repository.VccsRepository;
+
+/**
+ * Service responsible for fetching users information from AccountsAPI, fetching information about
+ * payments of those users from the database, getting information about CleanAirZones from VCCS API,
+ * and finally, integration of those data.
+ */
+@Service
+@AllArgsConstructor
+public class RetrieveSuccessfulPaymentsService {
+
+  private final AccountsRepository accountsRepository;
+  private final VccsRepository vccsRepository;
+  private final PaymentToCleanAirZoneMappingRepository paymentToCleanAirZoneMappingRepository;
+  private final PaymentSummaryRepository paymentSummaryRepository;
+
+  /**
+   * Method fetches list of users associated with the provided account and selects the user with the
+   * provided accountId.
+   *
+   * @param accountId Account of which users are going to be fetched
+   * @param accountUserId Specific account which data are going to be fetched
+   * @param pageNumber page number
+   * @param pageSize page size
+   */
+  public Pair<PaginationData, List<EnrichedPaymentSummary>> retrieveForSingleUser(UUID accountId,
+      UUID accountUserId, int pageNumber, int pageSize) {
+    List<AccountUserResponse> accountUsers = getAccountUsers(accountId);
+    List<AccountUserResponse> selectedAccountUser = accountUsers.stream()
+        .filter(accountUserResponse -> accountUserResponse.getAccountUserId().equals(accountUserId))
+        .collect(Collectors.toList());
+
+    return retrieveForSelectedUsers(selectedAccountUser, pageNumber, pageSize);
+  }
+
+  /**
+   * Method fetches list of users associated with the provided account and asks for data of all
+   * users associated with the account.
+   *
+   * @param accountId Account of which users are going to be fetched
+   * @param pageNumber page number
+   * @param pageSize page size
+   */
+  public Pair<PaginationData, List<EnrichedPaymentSummary>> retrieveForAccount(UUID accountId,
+      int pageNumber, int pageSize) {
+    List<AccountUserResponse> accountUsers = getAccountUsers(accountId);
+    return retrieveForSelectedUsers(accountUsers, pageNumber, pageSize);
+  }
+
+  /**
+   * Method receives list of users for which the payment data are going to be fetched from the
+   * database.
+   *
+   * @param accountUsers list of users
+   * @param pageNumber page number
+   * @param pageSize page size
+   */
+  private Pair<PaginationData, List<EnrichedPaymentSummary>> retrieveForSelectedUsers(
+      List<AccountUserResponse> accountUsers, int pageNumber, int pageSize) {
+    List<UUID> userIds = getUserIds(accountUsers);
+    Map<UUID, String> accountIdToAccountNameMap = getAccountIdToAccountNameMap(accountUsers);
+
+    List<PaymentSummary> paymentSummaries = composePaymentSummaries(userIds, pageNumber, pageSize);
+    List<EnrichedPaymentSummary> enrichedPaymentSummaries = enrichPaymentSummaries(
+        paymentSummaries, accountIdToAccountNameMap);
+    PaginationData paginationData = getPaginationData(userIds, pageNumber, pageSize);
+
+    return Pair.of(paginationData, enrichedPaymentSummaries);
+  }
+
+  /**
+   * Method receives userIds list whose payments are going to be fetched from DB, and composes it
+   * with clean air zone ids.
+   *
+   * @param userIds list of userIds
+   * @param pageNumber page number
+   * @param pageSize page size
+   * @return list of {@link PaymentSummary}.
+   */
+  private List<PaymentSummary> composePaymentSummaries(List<UUID> userIds, int pageNumber,
+      int pageSize) {
+    Map<UUID, UUID> paymentIdToCazIdMap = getPaymentIdToCleanAirZoneIdMap(userIds);
+
+    List<PaymentSummary> paymentSummaries = paymentSummaryRepository
+        .getPaginatedPaymentSummaryForUserIds(userIds, pageNumber, pageSize);
+
+    return paymentSummaries
+        .stream()
+        .map(paymentSummary -> paymentSummary.toBuilder()
+            .cleanAirZoneId(paymentIdToCazIdMap.get(paymentSummary.getPaymentId()))
+            .build())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Method receives collection of {@link AccountUserResponse} and returns list only with their
+   * IDs.
+   *
+   * @param accountUsers list of {@link AccountUserResponse}
+   * @return list of user Ids.
+   */
+  private List<UUID> getUserIds(List<AccountUserResponse> accountUsers) {
+    return accountUsers.stream().map(user -> user.getAccountUserId()).collect(
+        Collectors.toList());
+  }
+
+  /**
+   * Method returns helper collection which stores mapping between userId and it's name (e.g.
+   * 'bf0155a9-d7cf-4365-afea-621a3af48b16' => 'John Doe').
+   *
+   * @param accountUsers collection of {@link AccountUserResponse}
+   * @return helper collection.
+   */
+  private Map<UUID, String> getAccountIdToAccountNameMap(List<AccountUserResponse> accountUsers) {
+    return accountUsers.stream().collect(
+        Collectors.toMap(AccountUserResponse::getAccountUserId, this::selectNameForAccountUser));
+  }
+
+  /**
+   * Method performs an API call to the accounts service in order to get users information.
+   *
+   * @param accountId ID of the account of which users are going to be fetched.
+   * @return list of fetched users.
+   */
+  private List<AccountUserResponse> getAccountUsers(UUID accountId) {
+    Response<AccountUsersResponse> accountUsersBody = accountsRepository.getAllUsersSync(accountId);
+    return accountUsersBody.body().getUsers();
+  }
+
+  /**
+   * Based on the provided users ids, the counting queries are triggered on the database in order to
+   * return pagination information.
+   *
+   * @param userIds list of user ids
+   * @param pageNumber page number
+   * @param pageSize page size
+   * @return {@link PaginationData} object.
+   */
+  private PaginationData getPaginationData(List<UUID> userIds, int pageNumber, int pageSize) {
+    int totalPaymentsCount = paymentSummaryRepository.getTotalPaymentsCountForUserIds(userIds);
+    int pageCount = totalPaymentsCount / pageSize + ((totalPaymentsCount % pageSize == 0) ? 0 : 1);
+
+    return PaginationData.builder()
+        .pageSize(pageSize)
+        .pageNumber(pageNumber)
+        .totalElementsCount(totalPaymentsCount)
+        .pageCount(pageCount)
+        .build();
+  }
+
+  /**
+   * Helper method which queries the database for the paymentId and cleanAirZone association and
+   * then returns map with paymentId as key and cleanAirZoneId as value (e.g.
+   * '9cc2dd1a-905e-4eaf-af85-0b14f95aab89' => '43ea77cc-93cb-4df3-b731-5244c0de9cc8').
+   *
+   * @param userIds collection of userIds for whose payments database is queried.
+   * @return map
+   */
+  private Map<UUID, UUID> getPaymentIdToCleanAirZoneIdMap(List<UUID> userIds) {
+    List<PaymentToCleanAirZoneMapping> mappings = paymentToCleanAirZoneMappingRepository
+        .getPaymentToCleanAirZoneMapping(userIds);
+    Map<UUID, UUID> paymentToCleanAirZoneMap = mappings.stream().collect(Collectors
+        .toMap(PaymentToCleanAirZoneMapping::getPaymentId,
+            PaymentToCleanAirZoneMapping::getCleanAirZoneId));
+
+    return paymentToCleanAirZoneMap;
+  }
+
+  /**
+   * Method receives {@link PaymentSummary} collection along with helper collection which has stored
+   * mapping between cleanAirZoneID and cleanAirZone name.
+   *
+   * @param paymentSummaries collection of {@link PaymentSummary}
+   * @param accountIdToNameMap helper collection
+   * @return collection of {@link EnrichedPaymentSummary} with all data.
+   */
+  private List<EnrichedPaymentSummary> enrichPaymentSummaries(
+      List<PaymentSummary> paymentSummaries, Map<UUID, String> accountIdToNameMap) {
+    Map<UUID, String> cleanAirZonesIdToNameMap = getCleanAirZoneIdToCleanAirZoneNameMap();
+
+    List<EnrichedPaymentSummary> enrichedPaymentSummaries = paymentSummaries.stream()
+        .map(paymentSummary -> EnrichedPaymentSummary.builder()
+            .paymentId(paymentSummary.getPaymentId())
+            .entriesCount(paymentSummary.getEntriesCount())
+            .totalPaid(paymentSummary.getTotalPaid())
+            .cazName(cleanAirZonesIdToNameMap.get(paymentSummary.getCleanAirZoneId()))
+            .payerName(accountIdToNameMap.get(paymentSummary.getPayerId()))
+            .build()).collect(Collectors.toList());
+
+    return enrichedPaymentSummaries;
+  }
+
+  /**
+   * Method performs a call to {@link VccsRepository} to fetch cleanAirZones data and returns helper
+   * collection which maps cleanAirZone ID to cleanAirZone name (e.g.
+   * '1b33865b-1fcb-4d28-ac7d-d4586327de7d' => 'Birmingham').
+   */
+  private Map<UUID, String> getCleanAirZoneIdToCleanAirZoneNameMap() {
+    Response<CleanAirZonesDto> cleanAirZonesResponse = vccsRepository.findCleanAirZonesSync();
+    return cleanAirZonesResponse.body().getCleanAirZones().stream()
+        .collect(Collectors.toMap(CleanAirZoneDto::getCleanAirZoneId, CleanAirZoneDto::getName));
+  }
+
+  /**
+   * Helper method which returns proper payerName based on the provided {@link
+   * AccountUserResponse}.
+   *
+   * @param accountUser {@link AccountUserResponse} object.
+   * @return String with payerName.
+   */
+  private String selectNameForAccountUser(AccountUserResponse accountUser) {
+    if (accountUser.isOwner()) {
+      return "Administrator";
+    }
+    if (accountUser.isRemoved()) {
+      return "Deleted user";
+    }
+    return accountUser.getName();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -254,6 +254,8 @@ swagger:
         descriptions: retrieves a page of vehicles associated with a particular account
       chargeable-vehicles:
         descriptions: retrieves a page of chargeable vehicles
+      successful-payments:
+        description: retrieves a page of successful payments for a particular user.
     payments:
       create-vehicle-entrant:
         description: >-

--- a/src/test/java/uk/gov/caz/psr/controller/AccountsControllerTest.java
+++ b/src/test/java/uk/gov/caz/psr/controller/AccountsControllerTest.java
@@ -1,0 +1,162 @@
+package uk.gov.caz.psr.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.caz.psr.controller.AccountsController.ACCOUNTS_PATH;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.util.Pair;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import uk.gov.caz.correlationid.Configuration;
+import uk.gov.caz.correlationid.Constants;
+import uk.gov.caz.psr.controller.exception.InvalidRequestPayloadException;
+import uk.gov.caz.psr.controller.util.QueryStringValidator;
+import uk.gov.caz.psr.model.EnrichedPaymentSummary;
+import uk.gov.caz.psr.model.PaginationData;
+import uk.gov.caz.psr.service.AccountService;
+import uk.gov.caz.psr.service.RetrieveSuccessfulPaymentsService;
+import uk.gov.caz.psr.service.VehicleComplianceRetrievalService;
+
+@ContextConfiguration(classes = {ExceptionController.class, Configuration.class,
+    AccountsController.class})
+@WebMvcTest
+class AccountsControllerTest {
+
+  @MockBean
+  private VehicleComplianceRetrievalService vehicleComplianceRetrievalService;
+
+  @MockBean
+  private AccountService accountService;
+
+  @MockBean
+  private QueryStringValidator queryStringValidator;
+
+  @MockBean
+  private RetrieveSuccessfulPaymentsService retrieveSuccessfulPaymentsService;
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Nested
+  class RetrieveSuccessfulPayments {
+
+    private static final String ANY_ACCOUNT_ID = "dad034e6-ea18-4a58-a4f0-668a814a766b";
+    private static final String ANY_CORRELATION_ID = "fb8f036e-eaf0-42e2-bec2-51589d8018ff";
+    private static final String ANY_ACCOUNT_USER_ID = "2375e95c-4db8-44dc-b5aa-a73bc92fbf8a";
+
+    private static final String ANY_PAGE_NUMBER = "1";
+    private static final String ANY_PAGE_SIZE = "10";
+
+    private static final String RETRIEVE_SUCCESSFUL_PAYMENTS_PATH =
+        ACCOUNTS_PATH + "/{accountId}/payments";
+
+    @Test
+    public void shouldReturn400WhenCorrelationIdIsMissing() throws Exception {
+      mockMvc.perform(get(RETRIEVE_SUCCESSFUL_PAYMENTS_PATH, ANY_ACCOUNT_ID)
+          .accept(MediaType.APPLICATION_JSON)
+          .param("accountUserId", ANY_ACCOUNT_USER_ID)
+          .param("pageNumber", ANY_PAGE_NUMBER)
+          .param("pageSize", ANY_PAGE_SIZE))
+          .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void shouldReturn400WhenQueryValidationFails() throws Exception {
+      mockFailedQueryValidation();
+      performValidRequest().andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void shouldRetrieveSingleUserPaymentsWhenAccountUserIdIsPresentAndReturn200()
+        throws Exception {
+      mockSuccessfulQueryValidation();
+      mockSuccessfulSingleUserRetrieval();
+
+      performValidRequest().andExpect(status().isOk());
+      verify(retrieveSuccessfulPaymentsService)
+          .retrieveForSingleUser(any(), any(), anyInt(), anyInt());
+    }
+
+    @Test
+    public void shouldRetrieveAllUsersPaymentsWhenAccountUserIdIsMissingAndReturn200()
+        throws Exception {
+      mockSuccessfulQueryValidation();
+      mockSuccessfulAllUsersRetrieval();
+
+      mockMvc.perform(get(RETRIEVE_SUCCESSFUL_PAYMENTS_PATH, ANY_ACCOUNT_ID)
+          .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .accept(MediaType.APPLICATION_JSON)
+          .param("pageNumber", ANY_PAGE_NUMBER)
+          .param("pageSize", ANY_PAGE_SIZE))
+          .andExpect(status().isOk());
+
+      verify(retrieveSuccessfulPaymentsService).retrieveForAccount(any(), anyInt(), anyInt());
+    }
+
+    private void mockSuccessfulSingleUserRetrieval() {
+      when(
+          retrieveSuccessfulPaymentsService.retrieveForSingleUser(any(), any(), anyInt(), anyInt()))
+          .thenReturn(sampleServiceResult());
+    }
+
+    private void mockSuccessfulAllUsersRetrieval() {
+      when(retrieveSuccessfulPaymentsService.retrieveForAccount(any(), anyInt(), anyInt()))
+          .thenReturn(sampleServiceResult());
+    }
+
+    private Pair<PaginationData, List<EnrichedPaymentSummary>> sampleServiceResult() {
+      PaginationData paginationData = PaginationData.builder()
+          .pageCount(10)
+          .pageNumber(0)
+          .pageSize(10)
+          .totalElementsCount(100)
+          .build();
+
+      List<EnrichedPaymentSummary> enrichedPaymentSummaries = Arrays.asList(
+          EnrichedPaymentSummary.builder()
+              .paymentId(UUID.randomUUID())
+              .totalPaid(1000)
+              .payerName("Jan Brzechwa")
+              .entriesCount(10)
+              .cazName("Birmingham")
+              .build()
+      );
+
+      return Pair.of(paginationData, enrichedPaymentSummaries);
+    }
+
+    private ResultActions performValidRequest() throws Exception {
+      return mockMvc.perform(get(RETRIEVE_SUCCESSFUL_PAYMENTS_PATH, ANY_ACCOUNT_ID)
+          .header(Constants.X_CORRELATION_ID_HEADER, ANY_CORRELATION_ID)
+          .accept(MediaType.APPLICATION_JSON)
+          .param("accountUserId", ANY_ACCOUNT_USER_ID)
+          .param("pageNumber", ANY_PAGE_NUMBER)
+          .param("pageSize", ANY_PAGE_SIZE));
+    }
+
+    private void mockSuccessfulQueryValidation() {
+      doNothing().when(queryStringValidator).validateRequest(any(), any(), any());
+    }
+
+    private void mockFailedQueryValidation() {
+      doThrow(InvalidRequestPayloadException.class)
+          .when(queryStringValidator).validateRequest(any(), any(), any());
+    }
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/repository/PaymentSummaryRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/PaymentSummaryRepositoryTest.java
@@ -1,0 +1,62 @@
+package uk.gov.caz.psr.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentSummaryRepositoryTest {
+
+  @Mock
+  private JdbcTemplate jdbcTemplate;
+
+  @InjectMocks
+  private PaymentSummaryRepository paymentSummaryRepository;
+
+  @Nested
+  class GetPaginatedPaymentSummaryForUserIds {
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenUserIdsIsNull() {
+      // given
+      List<UUID> userIds = null;
+      int pageNumber = 0;
+      int pageSize = 10;
+
+      // when
+      Throwable throwable = catchThrowable(() -> paymentSummaryRepository
+          .getPaginatedPaymentSummaryForUserIds(userIds, pageNumber, pageSize));
+
+      // then
+      assertThat(throwable).isInstanceOf(NullPointerException.class)
+          .hasMessage("userIds cannot be null.");
+    }
+  }
+
+  @Nested
+  class GetTotalPaymentsCountForUserIds {
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenUserIdsIsNull() {
+      // given
+      List<UUID> userIds = null;
+
+      // when
+      Throwable throwable = catchThrowable(() -> paymentSummaryRepository
+          .getTotalPaymentsCountForUserIds(userIds));
+
+      // then
+      assertThat(throwable).isInstanceOf(NullPointerException.class)
+          .hasMessage("userIds cannot be null.");
+    }
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/repository/PaymentToCleanAirZoneMappingRepositoryTest.java
+++ b/src/test/java/uk/gov/caz/psr/repository/PaymentToCleanAirZoneMappingRepositoryTest.java
@@ -1,0 +1,42 @@
+package uk.gov.caz.psr.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentToCleanAirZoneMappingRepositoryTest {
+
+  @Mock
+  private JdbcTemplate jdbcTemplate;
+
+  @InjectMocks
+  private PaymentToCleanAirZoneMappingRepository paymentToCleanAirZoneMappingRepository;
+
+  @Nested
+  class GetPaymentToCleanAirZoneMapping {
+
+    @Test
+    public void shouldThrowNullPointerExceptionWhenUserIdsIsNull() {
+      // given
+      List<UUID> userIds = null;
+
+      // when
+      Throwable throwable = catchThrowable(
+          () -> paymentToCleanAirZoneMappingRepository.getPaymentToCleanAirZoneMapping(userIds));
+
+      // then
+      assertThat(throwable).isInstanceOf(NullPointerException.class)
+          .hasMessage("userIds cannot be null.");
+    }
+  }
+}

--- a/src/test/java/uk/gov/caz/psr/service/RetrieveSuccessfulPaymentsServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/RetrieveSuccessfulPaymentsServiceTest.java
@@ -1,0 +1,220 @@
+package uk.gov.caz.psr.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Pair;
+import retrofit2.Response;
+import uk.gov.caz.definitions.dto.CleanAirZoneDto;
+import uk.gov.caz.definitions.dto.CleanAirZonesDto;
+import uk.gov.caz.psr.dto.accounts.AccountUserResponse;
+import uk.gov.caz.psr.dto.accounts.AccountUsersResponse;
+import uk.gov.caz.psr.model.EnrichedPaymentSummary;
+import uk.gov.caz.psr.model.PaginationData;
+import uk.gov.caz.psr.model.PaymentSummary;
+import uk.gov.caz.psr.model.PaymentToCleanAirZoneMapping;
+import uk.gov.caz.psr.repository.AccountsRepository;
+import uk.gov.caz.psr.repository.PaymentSummaryRepository;
+import uk.gov.caz.psr.repository.PaymentToCleanAirZoneMappingRepository;
+import uk.gov.caz.psr.repository.VccsRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RetrieveSuccessfulPaymentsServiceTest {
+
+  @Mock
+  private AccountsRepository accountsRepository;
+
+  @Mock
+  private VccsRepository vccsRepository;
+
+  @Mock
+  private PaymentToCleanAirZoneMappingRepository paymentToCleanAirZoneMappingRepository;
+
+  @Mock
+  private PaymentSummaryRepository paymentSummaryRepository;
+
+  @InjectMocks
+  private RetrieveSuccessfulPaymentsService retrieveSuccessfulPaymentsService;
+
+  private final UUID ANY_ACCOUNT_ID = UUID.fromString("cce6da7e-c69f-11ea-bb00-5f164033a9da");
+
+  private final UUID OWNER_USER_ID = UUID.fromString("ab3e9f4b-4076-4154-b6dd-97c5d4800b47");
+  private final UUID ANY_USER_ID = UUID.fromString("88732cca-a5c7-4ad6-a60d-7edede935915");
+  private final UUID REMOVED_USER_ID = UUID.fromString("3f319922-71d2-432c-9757-8e5f060c2447");
+
+  private final int ANY_PAGE_NUMBER = 0;
+  private final int ANY_PAGE_SIZE = 10;
+
+  private final int ANY_PAYMENTS_COUNT_RESULT = 2;
+
+  @Nested
+  class RetrieveForSingleUser {
+
+    @Test
+    public void shouldIntegrateDataFromVariousSources() {
+      prepareAllMocks();
+
+      retrieveSuccessfulPaymentsService
+          .retrieveForAccount(ANY_ACCOUNT_ID, ANY_PAGE_NUMBER, ANY_PAGE_SIZE);
+
+      verify(accountsRepository).getAllUsersSync(any());
+      verify(paymentToCleanAirZoneMappingRepository).getPaymentToCleanAirZoneMapping(any());
+      verify(paymentSummaryRepository)
+          .getPaginatedPaymentSummaryForUserIds(any(), anyInt(), anyInt());
+      verify(vccsRepository).findCleanAirZonesSync();
+      verify(paymentSummaryRepository).getTotalPaymentsCountForUserIds(any());
+    }
+
+    @Test
+    public void shouldReturnEnrichedPaymentSummariesAndPaginationDataForSingleUser() {
+      prepareAllMocks();
+
+      Pair<PaginationData, List<EnrichedPaymentSummary>> result = retrieveSuccessfulPaymentsService
+          .retrieveForSingleUser(ANY_ACCOUNT_ID, OWNER_USER_ID, ANY_PAGE_NUMBER, ANY_PAGE_SIZE);
+
+      PaginationData paginationData = result.getFirst();
+      List<EnrichedPaymentSummary> enrichedPaymentSummaries = result.getSecond();
+
+      assertThat(paginationData).isNotNull();
+      assertThat(enrichedPaymentSummaries).isNotEmpty();
+    }
+  }
+
+  @Nested
+  class RetrieveForAccount {
+
+    @Test
+    public void shouldIntegrateDataFromVariousSources() {
+      prepareAllMocks();
+
+      retrieveSuccessfulPaymentsService
+          .retrieveForAccount(ANY_ACCOUNT_ID, ANY_PAGE_NUMBER, ANY_PAGE_SIZE);
+
+      verify(accountsRepository).getAllUsersSync(any());
+      verify(paymentToCleanAirZoneMappingRepository).getPaymentToCleanAirZoneMapping(any());
+      verify(paymentSummaryRepository)
+          .getPaginatedPaymentSummaryForUserIds(any(), anyInt(), anyInt());
+      verify(vccsRepository).findCleanAirZonesSync();
+      verify(paymentSummaryRepository).getTotalPaymentsCountForUserIds(any());
+    }
+
+    @Test
+    public void shouldReturnEnrichedPaymentSummariesAndPaginationDataForAllUsers() {
+      prepareAllMocks();
+
+      Pair<PaginationData, List<EnrichedPaymentSummary>> result = retrieveSuccessfulPaymentsService
+          .retrieveForAccount(ANY_ACCOUNT_ID, ANY_PAGE_NUMBER, ANY_PAGE_SIZE);
+
+      PaginationData paginationData = result.getFirst();
+      List<EnrichedPaymentSummary> enrichedPaymentSummaries = result.getSecond();
+
+      assertThat(paginationData).isNotNull();
+      assertThat(enrichedPaymentSummaries.size()).isEqualTo(2);
+    }
+  }
+
+  private void prepareAllMocks() {
+    when(accountsRepository.getAllUsersSync(ANY_ACCOUNT_ID)).thenReturn(sampleUsersResponse());
+    when(paymentToCleanAirZoneMappingRepository.getPaymentToCleanAirZoneMapping(any()))
+        .thenReturn(samplePaymentToCazMappingResult());
+    when(paymentSummaryRepository.getPaginatedPaymentSummaryForUserIds(any(), anyInt(), anyInt()))
+        .thenReturn(samplePaymentSummaryResult());
+    when(vccsRepository.findCleanAirZonesSync()).thenReturn(sampleCleanAirZonesResponse());
+    when(paymentSummaryRepository.getTotalPaymentsCountForUserIds(any()))
+        .thenReturn(ANY_PAYMENTS_COUNT_RESULT);
+  }
+
+  private List<PaymentToCleanAirZoneMapping> samplePaymentToCazMappingResult() {
+    return Arrays.asList(
+        PaymentToCleanAirZoneMapping.builder()
+            .paymentId(UUID.fromString("eae1d669-297e-41d0-b3b7-290d0300ca6d"))
+            .cleanAirZoneId(UUID.fromString("f64fdc1b-70f6-4c87-bfce-3643b2e4c714"))
+            .build(),
+        PaymentToCleanAirZoneMapping.builder()
+            .paymentId(UUID.fromString("749f8a00-257b-4d06-9589-b1ba7bbc934e"))
+            .cleanAirZoneId(UUID.fromString("5e554ef5-8513-4d98-8cd5-625dc6a77e80"))
+            .build()
+    );
+  }
+
+  private List<PaymentSummary> samplePaymentSummaryResult() {
+    return Arrays.asList(
+        PaymentSummary.builder()
+            .paymentId(UUID.fromString("eae1d669-297e-41d0-b3b7-290d0300ca6d"))
+            .entriesCount(10)
+            .payerId(OWNER_USER_ID)
+            .totalPaid(10000)
+            .build(),
+        PaymentSummary.builder()
+            .paymentId(UUID.fromString("749f8a00-257b-4d06-9589-b1ba7bbc934e"))
+            .entriesCount(5)
+            .payerId(ANY_USER_ID)
+            .totalPaid(5000)
+            .build()
+    );
+  }
+
+  private Response<CleanAirZonesDto> sampleCleanAirZonesResponse() {
+    List<CleanAirZoneDto> cazDtosList = sampleCleanAirZoneDtosList();
+    CleanAirZonesDto cleanAirZonesDto = CleanAirZonesDto.builder()
+        .cleanAirZones(cazDtosList)
+        .build();
+    return Response.success(cleanAirZonesDto);
+  }
+
+  private List<CleanAirZoneDto> sampleCleanAirZoneDtosList() {
+    return Arrays.asList(
+        CleanAirZoneDto.builder()
+            .cleanAirZoneId(UUID.fromString("f64fdc1b-70f6-4c87-bfce-3643b2e4c714"))
+            .name("Birmingham")
+            .build(),
+        CleanAirZoneDto.builder()
+            .cleanAirZoneId(UUID.fromString("5e554ef5-8513-4d98-8cd5-625dc6a77e80"))
+            .name("Leeds")
+            .build()
+    );
+  }
+
+  private Response<AccountUsersResponse> sampleUsersResponse() {
+    List<AccountUserResponse> userResponseList = sampleAccountUserResponseList();
+    AccountUsersResponse usersResponse = AccountUsersResponse.builder()
+        .users(userResponseList)
+        .build();
+
+    return Response.success(usersResponse);
+  }
+
+  private List<AccountUserResponse> sampleAccountUserResponseList() {
+    return Arrays.asList(
+        AccountUserResponse.builder()
+            .accountUserId(OWNER_USER_ID)
+            .owner(true)
+            .removed(false)
+            .build(),
+        AccountUserResponse.builder()
+            .accountUserId(ANY_USER_ID)
+            .owner(false)
+            .removed(false)
+            .name("Jan Kowalski")
+            .build(),
+        AccountUserResponse.builder()
+            .accountUserId(REMOVED_USER_ID)
+            .owner(false)
+            .removed(true)
+            .name("")
+            .build()
+    );
+  }
+}


### PR DESCRIPTION
**JIRA Card**
https://eaflood.atlassian.net/browse/CAZB-2164

----

**Changes description**
* The following changes exposes endpoint which returns data fetched from VCCS API (clean air zones data), Accounts API (users data) and from the database.
* The whole logic is stored in the `RetrieveSuccessfulPaymentsService` which exposes 2 public methods:
    * `retrieveForAccount` - for getting all users data based on provided `accountId`,
    * `retrieveForSingleUser` - for getting payments data for a single user associated with the `accountId`
* Data coming from the local database looks as follows:
    * Using `PaymentSummaryRepository#getTotalPaymentsCountForUserIds` the pagination data are fetched.
    * Using `PaymentSummaryRepository#getPaginatedPaymentSummaryForUserIds` the following payments data are fetched:
    ```
    {
        "paymentId": "XXXXXX",
        "entriesCount": 10,
        "totalPaid": 3,
        "cleanAirZoneId": null,
        "payerId": "XXXXXX"
    }
    ```
    Those data are stored in the `PaymentSummary` object. Note that this response has no `cleanAirZoneId` assigned.
    * Using `PaymentToCleanAirZoneMappingRepository#getPaymentToCleanAirZoneMapping` we get the information about Clean Air Zone associated with each payment:
     ```
    {
        "cleanAirZoneId": "XXXXXXX",
        "paymentId": "YYYYYYYY"
    }
    ```
    Those results are stored in `PaymentToCleanAirZoneMapping`
* Using `PaymentToCleanAirZoneMapping` the previously created `PaymentSummary` objects are enriched with `cleanAirZoneId` information.
* As we do not store information about clean air zone names and user names, those data are fetched from the AccountsAPI and VCCS - `PaymentSummary` objects are mapped to `EnrichedPaymentSummary` objects with changed attributes - `cleanAirZoneId` is mapped to `cazName` and `payerId` is mapped to `payerName`.

----

**Screenshots**
![Screenshot 2020-07-17 at 16 25 22](https://user-images.githubusercontent.com/4506633/88040483-4215d680-cb49-11ea-9622-c826bebdb64d.png)
