### PR TITLE
[CAZB-2437] [CAZB-2450] [CAZB-2450] Payments reporting views

### DIFF
--- a/src/main/resources/db/changelog/changes/0013-1.0-payments-reporting-views.yaml
+++ b/src/main/resources/db/changelog/changes/0013-1.0-payments-reporting-views.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0013-1.0-payments-reporting-views
+      author: Informed
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            encoding: utf8
+            endDelimiter: ;GO
+            path: ../rawSql/0013-1.0-payments-reporting-views.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true 

--- a/src/main/resources/db/changelog/rawSql/0013-1.0-payments-reporting-views.sql
+++ b/src/main/resources/db/changelog/rawSql/0013-1.0-payments-reporting-views.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE VIEW caz_reporting.number_payments_by_hour_caz_status_caz_method AS
+  SELECT DATE_TRUNC('hour', pay.insert_timestamp) AS hour, 
+    caz_name, 
+    payment_provider_status, 
+    payment_method, 
+    COUNT(*) AS no_payments 
+  FROM caz_payment.t_payment pay
+    INNER JOIN caz_payment.t_clean_air_zone_entrant_payment_match pay_match
+      ON pay.payment_id = pay_match.payment_id 
+    INNER JOIN caz_payment.t_clean_air_zone_entrant_payment entrant_pay
+      ON pay_match.clean_air_zone_entrant_payment_id = entrant_pay.clean_air_zone_entrant_payment_id
+    INNER JOIN caz_reporting.t_clean_air_zone caz
+      ON caz.clean_air_zone_id = entrant_pay.clean_air_zone_id
+  GROUP BY hour, caz_name, payment_provider_status, payment_method;


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/CAZB-2437
https://eaflood.atlassian.net/browse/CAZB-2450
https://eaflood.atlassian.net/browse/CAZB-2451

There is only one view required as aggregation over time periods can be handled in Quicksight for these metrics - this way the dataset will be as versatile as possible.