### PR TITLE
[CAZB-3404] Add indexes to payment matches

### DIFF
--- a/src/main/resources/db/changelog/changes/0016-1.0-add-indexes-for-payment-match-queries.yaml
+++ b/src/main/resources/db/changelog/changes/0016-1.0-add-indexes-for-payment-match-queries.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0016-1.0-add-indexes-for-payment-match-queries
+      author: Informed
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            encoding: utf8
+            endDelimiter: ;GO
+            path: ../rawSql/0016-1.0-add-indexes-for-payment-match-queries.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true 

--- a/src/main/resources/db/changelog/rawSql/0016-1.0-add-indexes-for-payment-match-queries.sql
+++ b/src/main/resources/db/changelog/rawSql/0016-1.0-add-indexes-for-payment-match-queries.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS clean_air_zone_entrant_payment_id ON caz_payment.t_clean_air_zone_entrant_payment_match (clean_air_zone_entrant_payment_id);


### PR DESCRIPTION
To improve query performance, an index is being created here against the payment_id field to avoid sequential scans.

Before:
![image](https://user-images.githubusercontent.com/6195772/98577152-6ee62900-22b3-11eb-9a5b-36fe2013c36a.png)

After (index scan applied):
![image](https://user-images.githubusercontent.com/6195772/98577185-7a395480-22b3-11eb-979f-ab6a2fb32349.png)

Whilst this is not suspected to resolve the issue in its entirety, this should help improve response times in duplicate payment prevention both in IOD and the Account Pay service.