### PR TITLE
[CAZB-3404] Fix last page detection on chargeable-vehicle pagination

### DIFF
--- a/src/main/java/uk/gov/caz/psr/service/ChargeableVehiclesService.java
+++ b/src/main/java/uk/gov/caz/psr/service/ChargeableVehiclesService.java
@@ -109,7 +109,7 @@ public class ChargeableVehiclesService {
       UUID cazId, String direction, int pageSize) {
 
     ChargeableVehiclesResponseDto accountVehicles = accountService
-        .getAccountVehiclesByCursor(accountId, direction, pageSize, vrn, cazId);
+        .getAccountVehiclesByCursor(accountId, direction, pageSize + 1, vrn, cazId);
     List<ChargeableVehicle> chargeableVehicles = accountVehicles.getVehicles().stream()
         .map(vehicleWithCharges ->
             ChargeableVehicle.from(vehicleWithCharges.getVrn(),

--- a/src/test/java/uk/gov/caz/psr/service/ChargeableVehiclesServiceTest.java
+++ b/src/test/java/uk/gov/caz/psr/service/ChargeableVehiclesServiceTest.java
@@ -209,7 +209,7 @@ class ChargeableVehiclesServiceTest {
 
   private void mockAccountServiceChargeableVehiclesCall() throws JsonProcessingException {
     when(accountService
-        .getAccountVehiclesByCursor(ANY_ACCOUNT_ID, "previous", ANY_PAGE_SIZE, ANY_CURSOR_VRN,
+        .getAccountVehiclesByCursor(ANY_ACCOUNT_ID, "previous", ANY_PAGE_SIZE + 1, ANY_CURSOR_VRN,
             ANY_CAZ_ID))
         .thenReturn(exampleChargeableVehiclesResponseDto());
   }
@@ -233,7 +233,7 @@ class ChargeableVehiclesServiceTest {
 
   private void mockAccountServiceNonChargeableVehiclesCall(int pageSize) {
     when(accountService
-        .getAccountVehiclesByCursor(ANY_ACCOUNT_ID, "previous", pageSize, ANY_CURSOR_VRN,
+        .getAccountVehiclesByCursor(ANY_ACCOUNT_ID, "previous", pageSize + 1, ANY_CURSOR_VRN,
             ANY_CAZ_ID))
         .thenReturn(exampleNonChargeableVehiclesResponseDto());
   }


### PR DESCRIPTION
* Fetches `pageSize + 1` VRNs from Accounts API in order to be able to verify if we're fetching the last page.
* The redundant VRN is then removed from results in `chargeableVehiclesToDtoConverter`