### PR TITLE
[CAZB-3871] Update Spring to 2.2.12 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.1.RELEASE</version> <!-- lookup parent from repository -->
+    <version>2.2.12.RELEASE</version> <!-- lookup parent from repository -->
   </parent>
   <groupId>uk.gov.caz.psr</groupId>
   <artifactId>payment-service</artifactId>


### PR DESCRIPTION
Update Spring to 2.2.12 release to benefit from performance improvements detailed in release notes at https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.2-Release-Notes