### PR TITLE
[CAZB-3872] Prevent Spring double init phase causing service timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <dependency>
       <groupId>com.amazonaws.serverless</groupId>
       <artifactId>aws-serverless-java-container-springboot2</artifactId>
-      <version>1.4</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws.secretsmanager</groupId>


### PR DESCRIPTION
Prevent Spring double init phase causing service timeout. The default character set override can now also be removed as it has been resolved in 1.5.1 of the aws-serverless-java-container-springboot2 package.