### PR TITLE
[CAZSM-110] Redis log clean-up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <dependency>
       <groupId>com.amazonaws.serverless</groupId>
       <artifactId>aws-serverless-java-container-springboot2</artifactId>
-      <version>1.4</version>
+      <version>1.5.2</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws.secretsmanager</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <rest-assured.version>4.0.0</rest-assured.version>
     <internal.libraries.version>2.14.0-SNAPSHOT</internal.libraries.version>
-    <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
+    <spring-cloud.version>Greenwich.SR6</spring-cloud.version>
 
     <codeCoverage.minCoveredRatio>1</codeCoverage.minCoveredRatio>
     <codeCoverage.classMaxMissedCount>0</codeCoverage.classMaxMissedCount>

--- a/src/main/java/uk/gov/caz/psr/amazonaws/StreamLambdaHandler.java
+++ b/src/main/java/uk/gov/caz/psr/amazonaws/StreamLambdaHandler.java
@@ -38,8 +38,7 @@ public class StreamLambdaHandler implements RequestStreamHandler {
 
   static {
     try {
-      // For applications that take longer than 10 seconds to start, use the async builder:
-      log.info("Initialising lambda handler");
+      log.info("Initializing lambda handler");
       
       String listOfActiveSpringProfiles =
           System.getenv("SPRING_PROFILES_ACTIVE");
@@ -59,10 +58,10 @@ public class StreamLambdaHandler implements RequestStreamHandler {
             .buildAndInitialize();
       }
       
-      log.info("Lambda handler initialisation finished");
+      log.info("Lambda handler initialization finished");
     } catch (ContainerInitializationException e) {
-      // if we fail here. We re-throw the exception to force another cold start
-      log.info("Initialisation of lambda failed");
+      // If we fail here. We re-throw the exception to force another cold start
+      log.info("Initialization of lambda failed");
       throw new IllegalStateException("Could not initialize Spring Boot application", e);
     }
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ services:
     rootUrl: https://publicapi.payments.service.gov.uk
     api-key: to-be-replaced-by-external-value
   vehicle-compliance-checker:
-    root-url: https://dev-api.cleanairzonevehiclecheck.co.uk
+    root-url: https://localhost:1090
   accounts:
     root-url: http://localhost:1091
   whitelist:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ services:
     rootUrl: https://publicapi.payments.service.gov.uk
     api-key: to-be-replaced-by-external-value
   vehicle-compliance-checker:
-    root-url: https://localhost:1090
+    root-url: http://localhost:1090
   accounts:
     root-url: http://localhost:1091
   whitelist:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,10 @@ logging:
           correlationid: INFO
 
 spring:
+  data:
+    redis:
+      repositories:
+        enabled: false
   jpa:
     open-in-view: false
   liquibase:
@@ -41,7 +45,7 @@ services:
     rootUrl: https://publicapi.payments.service.gov.uk
     api-key: to-be-replaced-by-external-value
   vehicle-compliance-checker:
-    root-url: http://localhost:1090
+    root-url: https://dev-api.cleanairzonevehiclecheck.co.uk
   accounts:
     root-url: http://localhost:1091
   whitelist:


### PR DESCRIPTION
This PR updates 2 parts of cold-start log entries. The first is a move to Greenwich.SR6 for the Spring cloud version to remove the following example from log entries (see https://github.com/spring-cloud/spring-cloud-commons/issues/657):

`Bean 'org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration' of type [org.springframework.cloud.autoconfigure.ConfigurationPropertiesRebinderAutoConfiguration$$EnhancerBySpringCGLIB$$84298a94] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying)`

The second is to reduce noise of the following logs by disabling Redis auto-configuration (given a custom bean for elasticache integration is present) via Spring config:

```
s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data Redis repositories in DEFAULT mode. | 13/01/2021 19:59:39.579 INFO 1 --- [ Thread-0] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data Redis repositories in DEFAULT mode.-- | --
```

Note that a test has been run against a local redis instance to make sure this setting does not disable Redis in full, just the autoconfiguration attempts by Spring