### PR TITLE
[CAZB-3905] email_confirmation_sent population fix

### DIFF
--- a/src/main/resources/db/changelog/changes/0019-1.0-add-email-confirmation-sent-to-t-payment-table.yaml
+++ b/src/main/resources/db/changelog/changes/0019-1.0-add-email-confirmation-sent-to-t-payment-table.yaml
@@ -3,11 +3,13 @@ databaseChangeLog:
       id: 0019-1.0
       author: antoni.pstras
       changes:
-        - sqlFile:
-            dbms: postgresql
-            encoding: utf8
-            endDelimiter: ;GO
-            path: ../rawSql/0019-1.0-add_email_confirmation_sent_to_t_payment.sql
-            relativeToChangelogFile: true
-            splitStatements: true
-            stripComments: true
+        - addColumn:
+            schemaName: CAZ_PAYMENT
+            tableName: T_PAYMENT
+            columns:
+              - column:
+                  name: email_confirmation_sent
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/src/main/resources/db/changelog/changes/0020-1.0-set_already_existing_email_confirmations_to_true.yaml
+++ b/src/main/resources/db/changelog/changes/0020-1.0-set_already_existing_email_confirmations_to_true.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0020-1.0
+      author: antoni.pstras
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            encoding: utf8
+            endDelimiter: ;GO
+            path: ../rawSql/0020-1.0-populate_email_confirmation_sent.sql
+            relativeToChangelogFile: true
+            splitStatements: true
+            stripComments: true

--- a/src/main/resources/db/changelog/rawSql/0019-1.0-add_email_confirmation_sent_to_t_payment.sql
+++ b/src/main/resources/db/changelog/rawSql/0019-1.0-add_email_confirmation_sent_to_t_payment.sql
@@ -1,5 +1,0 @@
--- Add `email_confirmation_sent` attribute to T_PAYMENT table:
-ALTER TABLE CAZ_PAYMENT.t_payment ADD COLUMN email_confirmation_sent boolean DEFAULT false NOT NULL;
-
--- Set email_confirmation_sent=true for already existing records:
-UPDATE CAZ_PAYMENT.t_payment SET email_confirmation_sent = true;

--- a/src/main/resources/db/changelog/rawSql/0020-1.0-populate_email_confirmation_sent.sql
+++ b/src/main/resources/db/changelog/rawSql/0020-1.0-populate_email_confirmation_sent.sql
@@ -1,0 +1,8 @@
+-- Disables all triggers for the current session
+SET session_replication_role = replica;
+
+-- Set email_confirmation_sent=true for already existing records:
+UPDATE CAZ_PAYMENT.t_payment SET email_confirmation_sent = true;
+
+-- Enables triggers back
+SET session_replication_role = DEFAULT;


### PR DESCRIPTION
**JIRA Card**:
* https://eaflood.atlassian.net/browse/CAZB-3905

**Problem**: 
* On the ST environment, the migration was causing a timeout (probably because of triggered updates)
* Because of the timeout, the transaction was being rolled back, which effectively meant that the `email_confirmation_sent` column was not added to the table.

**Solution**:
* The migration was split into two - one for the column addition and another one for the population of the values.
* Disabled triggers for the database session.