### PR TITLE
[CAZB-4175] Move check for count to QueryUtil class

### DIFF
--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/CazIdSpecification.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/CazIdSpecification.java
@@ -23,21 +23,22 @@ public class CazIdSpecification implements Specification<EntrantPaymentMatchInfo
   private final UUID cazId;
 
   @Override
-  public Predicate toPredicate(Root<EntrantPaymentMatchInfo> root, CriteriaQuery<?> criteriaQuery,
-      CriteriaBuilder criteriaBuilder) {
+  public Predicate toPredicate(Root<EntrantPaymentMatchInfo> root,
+      CriteriaQuery<?> criteriaQuery, CriteriaBuilder criteriaBuilder) {
     Join<EntrantPaymentMatchInfo, EntrantPaymentInfo> entrantPaymentInfoJoin;
-    if(currentQueryIsCountRecords(criteriaQuery)) {
+    if (QueryUtil.currentQueryIsCountRecords(criteriaQuery)) {
       QueryUtil.getOrCreateJoin(root, EntrantPaymentMatchInfo_.paymentInfo);
-      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoin(root, EntrantPaymentMatchInfo_.entrantPaymentInfo);
+      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoin(root,
+          EntrantPaymentMatchInfo_.entrantPaymentInfo);
     } else {
-      QueryUtil.getOrCreateJoinFetch(root, EntrantPaymentMatchInfo_.paymentInfo);
-      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoinFetch(root, EntrantPaymentMatchInfo_.entrantPaymentInfo);
+      QueryUtil.getOrCreateJoinFetch(root,
+          EntrantPaymentMatchInfo_.paymentInfo);
+      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoinFetch(root,
+          EntrantPaymentMatchInfo_.entrantPaymentInfo);
     }
 
     return criteriaBuilder.equal(
-        entrantPaymentInfoJoin.get(EntrantPaymentInfo_.cleanAirZoneId),
-        cazId
-    );
+        entrantPaymentInfoJoin.get(EntrantPaymentInfo_.cleanAirZoneId), cazId);
   }
 
   /**
@@ -48,8 +49,4 @@ public class CazIdSpecification implements Specification<EntrantPaymentMatchInfo
     return new CazIdSpecification(cazId);
   }
 
-  private boolean currentQueryIsCountRecords(CriteriaQuery<?> criteriaQuery) {
-    return criteriaQuery.getResultType() == Long.class
-        || criteriaQuery.getResultType() == long.class;
-  }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/OmitNotPaidPaymentInfoSpecification.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/OmitNotPaidPaymentInfoSpecification.java
@@ -22,17 +22,16 @@ public class OmitNotPaidPaymentInfoSpecification implements Specification<Entran
       CriteriaBuilder criteriaBuilder) {
 
     Join<EntrantPaymentMatchInfo, EntrantPaymentInfo> entrantPaymentInfoJoin;
-    if(currentQueryIsCountRecords(criteriaQuery)) {
-      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoin(root, EntrantPaymentMatchInfo_.entrantPaymentInfo);
+    if (QueryUtil.currentQueryIsCountRecords(criteriaQuery)) {
+      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoin(root,
+          EntrantPaymentMatchInfo_.entrantPaymentInfo);
     } else {
-      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoinFetch(root, EntrantPaymentMatchInfo_.entrantPaymentInfo);
+      entrantPaymentInfoJoin = QueryUtil.getOrCreateJoinFetch(root,
+          EntrantPaymentMatchInfo_.entrantPaymentInfo);
     }
-    return criteriaBuilder.notEqual(entrantPaymentInfoJoin.get(EntrantPaymentInfo_.paymentStatus),
+    return criteriaBuilder.notEqual(
+        entrantPaymentInfoJoin.get(EntrantPaymentInfo_.paymentStatus),
         InternalPaymentStatus.NOT_PAID);
   }
-
-
-  private boolean currentQueryIsCountRecords(CriteriaQuery<?> criteriaQuery) {
-    return criteriaQuery.getResultType() == Long.class || criteriaQuery.getResultType() == long.class;
-  }
+  
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationByPaymentSubmittedDate.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationByPaymentSubmittedDate.java
@@ -2,12 +2,10 @@ package uk.gov.caz.psr.service.paymentinfo;
 
 import java.time.ZoneId;
 import java.util.Optional;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import uk.gov.caz.psr.model.PaymentInfoRequestAttributes;
-import uk.gov.caz.psr.model.info.EntrantPaymentInfo;
 import uk.gov.caz.psr.model.info.EntrantPaymentMatchInfo;
 import uk.gov.caz.psr.model.info.EntrantPaymentMatchInfo_;
 import uk.gov.caz.psr.model.info.PaymentInfo;
@@ -29,10 +27,12 @@ public class PaymentInfoSpecificationByPaymentSubmittedDate implements PaymentIn
     return (root, criteriaQuery, criteriaBuilder) -> {
 
       Join<EntrantPaymentMatchInfo, PaymentInfo> joinPayment;
-      if(currentQueryIsCountRecords(criteriaQuery)) {
-        joinPayment = QueryUtil.getOrCreateJoin(root, EntrantPaymentMatchInfo_.paymentInfo);
+      if (QueryUtil.currentQueryIsCountRecords(criteriaQuery)) {
+        joinPayment = QueryUtil.getOrCreateJoin(root,
+            EntrantPaymentMatchInfo_.paymentInfo);
       } else {
-        joinPayment = QueryUtil.getOrCreateJoinFetch(root, EntrantPaymentMatchInfo_.paymentInfo);
+        joinPayment = QueryUtil.getOrCreateJoinFetch(root,
+            EntrantPaymentMatchInfo_.paymentInfo);
       }
 
       return criteriaBuilder.and(
@@ -49,8 +49,5 @@ public class PaymentInfoSpecificationByPaymentSubmittedDate implements PaymentIn
           )
       );
     };
-  }
-  private boolean currentQueryIsCountRecords(CriteriaQuery<?> criteriaQuery) {
-    return criteriaQuery.getResultType() == Long.class || criteriaQuery.getResultType() == long.class;
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateFromAndTo.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/PaymentInfoSpecificationTravelDateFromAndTo.java
@@ -1,7 +1,6 @@
 package uk.gov.caz.psr.service.paymentinfo;
 
 import java.util.Optional;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
@@ -30,12 +29,13 @@ public class PaymentInfoSpecificationTravelDateFromAndTo implements PaymentInfoS
 
 
       Join<EntrantPaymentMatchInfo, EntrantPaymentInfo> entrantPaymentInfoJoin;
-      if(currentQueryIsCountRecords(criteriaQuery)) {
-        entrantPaymentInfoJoin = QueryUtil.getOrCreateJoin(root, EntrantPaymentMatchInfo_.entrantPaymentInfo);
+      if (QueryUtil.currentQueryIsCountRecords(criteriaQuery)) {
+        entrantPaymentInfoJoin = QueryUtil.getOrCreateJoin(root,
+            EntrantPaymentMatchInfo_.entrantPaymentInfo);
       } else {
-        entrantPaymentInfoJoin = QueryUtil.getOrCreateJoinFetch(root, EntrantPaymentMatchInfo_.entrantPaymentInfo);
+        entrantPaymentInfoJoin = QueryUtil.getOrCreateJoinFetch(root,
+            EntrantPaymentMatchInfo_.entrantPaymentInfo);
       }
-
 
       return criteriaBuilder.and(
           criteriaBuilder.greaterThanOrEqualTo(
@@ -48,9 +48,5 @@ public class PaymentInfoSpecificationTravelDateFromAndTo implements PaymentInfoS
           )
       );
     };
-  }
-
-  private boolean currentQueryIsCountRecords(CriteriaQuery<?> criteriaQuery) {
-    return criteriaQuery.getResultType() == Long.class || criteriaQuery.getResultType() == long.class;
   }
 }

--- a/src/main/java/uk/gov/caz/psr/service/paymentinfo/QueryUtil.java
+++ b/src/main/java/uk/gov/caz/psr/service/paymentinfo/QueryUtil.java
@@ -1,5 +1,6 @@
 package uk.gov.caz.psr.service.paymentinfo;
 
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.Attribute;
@@ -30,7 +31,7 @@ public class QueryUtil {
   }
 
   /**
-   * Helper method to create or find existing join, to avoid multiple joins on the same table.
+   * Helper method to create or find existing join with inner fetches for Lazy loading entities, to avoid multiple joins on the same table.
    *
    * @param from {@link Root}
    * @param attribute {@link PluralAttribute}
@@ -43,5 +44,19 @@ public class QueryUtil {
         .filter(fetch -> attribute.getName().equals(fetch.getAttribute().getName()))
         .findFirst()
         .orElseGet(() -> from.fetch(attribute.getName()));
+  }
+  
+  /**
+   * Method to determine whether a query is being issued to identify the count
+   * value of a paged response.
+   * 
+   * @param criteriaQuery {@link CriteriaQuery}
+   * @return boolean value for whether a query is to identify the count value of
+   *         a paged response.
+   */
+  public static boolean currentQueryIsCountRecords(
+      CriteriaQuery<?> criteriaQuery) {
+    return criteriaQuery.getResultType() == Long.class
+        || criteriaQuery.getResultType() == long.class;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -421,4 +421,4 @@ swagger:
 api:
   charge-settlement:
     date-query-range: 14
-    page-size: 2
+    page-size: 1500


### PR DESCRIPTION
Moves currentQueryIsCountRecords to the QueryUtil class to keep things DRY.