### PR TITLE
[NON-JIRA] Remove clean agent step in dev to allow image caching

### DIFF
--- a/.drone2.yml
+++ b/.drone2.yml
@@ -146,15 +146,6 @@ services:
       - 6379
 steps:
 
-  # Clean agent images and containers to prevent disk space overuse
-  - name: clean agent
-    image: docker:19.03.11-git
-    commands:
-      - docker system prune -f
-    volumes:
-      - name: docker_sock
-        path: /var/run/docker.sock
-
   # Build docker images
   - name: build docker maven base
     image: docker:19.03.11-git


### PR DESCRIPTION
Improves build speed by allowing for docker image caching. This serves 2 benefits - making builds faster to deploy; second - reducing the number of pulls issued to Dockerhub (so reduces chance of hitting rate limits).